### PR TITLE
Replace suggested Android SBT plugin with a maintained one

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ A curated list of awesome Scala frameworks, libraries and software. Inspired by 
 
 * [Scaloid](https://github.com/pocorall/scaloid) - Less painful Android development with Scala.
 * [Macroid](https://github.com/macroid/macroid) - A modular functional UI language for Android.
-* [sbt-android-plugin](https://github.com/jberkel/android-plugin) - A sbt plugin for Android development in Scala.
+* [Android SDK Plugin for SBT](https://github.com/pfn/android-sdk-plugin) - A sbt plugin that adds tasks for developing Android applications.
 
 ## HTTP
 


### PR DESCRIPTION
The suggested Android SBT plugin has not seen an update in 10 months and does not work with the latest SBTs.

The project suggested in this PR is maintained, works with the latest SBT and has much better documentation.
