### PR TITLE
Remove Lift because it is not awesome

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ A curated list of awesome Scala frameworks, libraries and software. Inspired by 
 * [Play](https://github.com/playframework/playframework) - Makes it easy to build scalable, fast and real-time web applications with Java & Scala.
 * [Skinny Framework](https://github.com/skinny-framework/skinny-framework) - A full-stack web app framework upon Scalatra for rapid Development in Scala.
 * [Scalatra](https://github.com/scalatra/scalatra) - Tiny Scala high-performance, async web framework, inspired by Sinatra.
-* [Lift](https://github.com/lift/framework) - Secure and powerful full stack web framework.
 * [Spray](https://github.com/spray/spray) - A suite of scala libraries for building and consuming RESTful web services on top of Akka.
 * [Finatra](https://github.com/twitter/finatra) - A sinatra-inspired web framework for scala, running on top of Finagle.
 * [Blue Eyes](https://github.com/jdegoes/blueeyes) - A lightweight Web 3.0 framework for Scala, featuring a purely asynchronous architecture, extremely high-performance, massive scalability, high usability, and a functional, composable design.


### PR DESCRIPTION
I've been a part of multiple web app rewrites in order to move away from Lift

While it may have been a good choice at one point in time (before scala got any other web frameworks) I would never recommend anyone to start using it today.
