### PR TITLE
Adding pac4j on the Auth group

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ A community driven list of useful Scala libraries, frameworks and software. This
 * [scala-oauth2-provider](https://github.com/nulab/scala-oauth2-provider) - OAuth 2.0 server-side implementation written in Scala.
 * [SecureSocial](https://github.com/jaliss/securesocial) - A module that provides OAuth, OAuth2 and OpenID authentication for Play Framework applications.
 * [play2-auth](https://github.com/t2v/play2-auth) - Play2.x Authentication and Authorization module.
+* [pac4j](https://github.com/leleuj/pac4j) - Profile & Authentication Client in Java for CAS, OAuth, OpenID, SAML, HTTP... protocols
 
 ## Testing
 


### PR DESCRIPTION
pac4j is a Profile & Authentication Client for Java (it's a global rebuilding of the scribe-up library). It targets all the authentication mechanisms supporting the following flow:

From the client application, redirect the user to the "provider" for authentication (HTTP 302)
After successful authentication, redirect back the user from the "provider" to the client application (HTTP 302) and get the user credentials
With these credentials, get the profile of the authenticated user (direct call from the client application to the "provider").
It has a very simple and unified API to support these 6 authentication mechanisms on client side:

OAuth (1.0 & 2.0)
CAS (1.0, 2.0, SAML, logout & proxy)
HTTP (form & basic auth authentications)
OpenID
SAML (2.0) (still experimental)
GAE UserService
There are 6 libraries implementing pac4j for the following environments:

the CAS server (using the cas-server-support-pac4j library)
the Play 2.x framework (using the play-pac4j_java and play-pac4j_scala libraries)
any basic J2E environment (using the j2e-pac4j library)
the Apache Shiro library (using the buji-pac4j library)
the Spring Security library (using the spring-security-pac4j library)
the Ratpack JVM toolkit (using the ratpack-pac4j module).
It's available under the Apache 2 license.

cc @leleuj
