### PR TITLE
Add Log4s: logging library for Scala.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ A community driven list of useful Scala libraries, frameworks and software. This
 * [Scala Async](https://github.com/scala/async) — An asynchronous programming facility for Scala.
 * [Resolvable](https://github.com/resolvable/resolvable) — A library to optimize fetching immutable data structures from several endpoints in several formats.
 * [Scala Blitz](http://scala-blitz.github.io/) – A library to speed up Scala collection operations by removing runtime overheads during compilation, and a custom data-parallel operation runtime.
+* [Log4s](http://log4s.org) - Fast, Scala-friendly logging bindings on top of [SLF4J](http://slf4j.org/). Uses macros for extreme performance.
 
 ## Android
 


### PR DESCRIPTION
The Log4s library is solid and in production at a couple companies now.
