### PR TITLE
Added Salat as ORM for MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ A community driven list of useful Scala libraries, frameworks and software. This
 * [ReactiveMongo](https://github.com/ReactiveMongo/ReactiveMongo) — Reactive Scala Driver for MongoDB.
 * [Phantom](https://github.com/websudosuk/phantom) — Async type safe Scala DSL for Apache Cassandra.
 * [ReactiveCouchbase](http://reactivecouchbase.org/) — Reactive Scala Driver for Couchbase. Also includes a Play plug-in. An official plug-in is also in development.
+* [Salat](https://github.com/novus/salat/) — ORM for MongoDB. A related Play-plugin is also available.
+
 
 ## Web Frameworks
 


### PR DESCRIPTION
Salat is a very good tool to access MongoDB. It serializes case classes to MongoDB DBObjects and the other way around. Also JSON support is included.
