### PR TITLE
List jOOQ in the database access section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A community driven list of useful Scala libraries, frameworks and software. This
 * [ReactiveCouchbase](http://reactivecouchbase.org/) — Reactive Scala Driver for Couchbase. Also includes a Play plug-in. An official plug-in is also in development.
 * [Salat](https://github.com/novus/salat/) — ORM for MongoDB. A related Play-plugin is also available.
 * [Sorm](https://github.com/sorm/sorm) — A functional boilerplate-free Scala ORM.
-
+* [jOOQ](http://www.jooq.org) - A Java DSL that emulates standard SQL for 17 RDBMS and that works quite well with Scala as well.
 
 ## Web Frameworks
 


### PR DESCRIPTION
Hi there,

I was made aware of this list by a jOOQ user and was wondering if you're also accepting Java APIs in your list. We have many Scala/jOOQ users and also a couple of paying customers using this combination with a lot of joy. Of course, the usual interoperability issues (boxed number types, `Option`) appear also here, but in general, writing SQL in Scala with jOOQ is awesome!

If it doesn't match, feel free to reject.

Cheers
Lukas
