### PR TITLE
Add script to query GH project popularity/activity.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+
+# project specific
+.access-token

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ A community driven list of useful Scala libraries, frameworks and software. This
 * [Scrunch](http://crunch.apache.org/scrunch.html) — A Scala wrapper for [Apache Crunch](http://crunch.apache.org/index.html) which provides a framework for writing, testing, and running MapReduce pipelines.
 * [GridScale](https://github.com/romainreuillon/gridscale) — A Scala API for computing clusters and grids.
 * [BIDMach](https://github.com/BIDData/BIDMach) - CPU and GPU machine learning library, using JNI for GPU computation.
-* [Scoobi](https://github.com/nicta/scoobi) - Write type-safe Hadoop programs in idiomatic Scala way
+* [Scoobi] (https://github.com/nicta/scoobi) - Write type-safe Hadoop programs in idiomatic Scala way
 * [Gearpump](https://github.com/intel-hadoop/gearpump) - Lightweight real-time big data streaming engine
 * [Scoozie](https://github.com/klout/scoozie) - Scala DSL on top of Oozie XML
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ A community driven list of useful Scala libraries, frameworks and software. This
 * [Scrunch](http://crunch.apache.org/scrunch.html) — A Scala wrapper for [Apache Crunch](http://crunch.apache.org/index.html) which provides a framework for writing, testing, and running MapReduce pipelines.
 * [GridScale](https://github.com/romainreuillon/gridscale) — A Scala API for computing clusters and grids.
 * [BIDMach](https://github.com/BIDData/BIDMach) - CPU and GPU machine learning library, using JNI for GPU computation.
-* [Scoobi] (https://github.com/nicta/scoobi) - Write type-safe Hadoop programs in idiomatic Scala way
+* [Scoobi](https://github.com/nicta/scoobi) - Write type-safe Hadoop programs in idiomatic Scala way
 * [Gearpump](https://github.com/intel-hadoop/gearpump) - Lightweight real-time big data streaming engine
 * [Scoozie](https://github.com/klout/scoozie) - Scala DSL on top of Oozie XML
 

--- a/README.md
+++ b/README.md
@@ -35,273 +35,273 @@ A community driven list of useful Scala libraries, frameworks and software. This
 
 *Database access libraries in Scala.*
 
-* [Activate](https://github.com/fwbrasil/activate) — Pluggable object persistence in Scala.
-* [Elastic4s](https://github.com/sksamuel/elastic4s) - A scala DSL / reactive client for Elasticsearch
-* [Phantom](https://github.com/websudos/phantom) — Reactive type safe Scala driver for Apache Cassandra.
-* [ReactiveNeo](https://github.com/websudos/reactiveneo) - Reactive type-safe Scala driver for Neo4J.
-* [PostgreSQL and MySQL async](https://github.com/mauricio/postgresql-async) — Async database drivers to talk to PostgreSQL and MySQL in Scala.
-* [ReactiveCouchbase](http://reactivecouchbase.org/) — Reactive Scala Driver for Couchbase. Also includes a Play plug-in. An official plug-in is also in development.
-* [ReactiveMongo](https://github.com/ReactiveMongo/ReactiveMongo) — Reactive Scala Driver for MongoDB.
-* [Salat](https://github.com/novus/salat/) — ORM for MongoDB. A related Play-plugin is also available.
-* [Scala ActiveRecord](https://github.com/aselab/scala-activerecord) — ORM library for scala, inspired by ActiveRecord of Ruby on Rails.
-* [ScalikeJDBC](https://github.com/scalikejdbc/scalikejdbc) — A tidy SQL-based DB access library for Scala developers.
-* [Slick](https://github.com/slick/slick) — Modern database query and access library for Scala.
-* [Sorm](https://github.com/sorm/sorm) — A functional boilerplate-free Scala ORM.
-* [Squeryl](https://github.com/squeryl/squeryl) — A Scala DSL for talking with databases with minimum verbosity and maximum type safety.
-* [doobie](https://github.com/tpolecat/doobie) - Pure functional JDBC layer for Scala.
-* [MapperDao](https://github.com/kostaskougios/mapperdao) - An ORM library for oracle, mysql, mssql, and postgresql
-* [Tepkin](https://github.com/fehmicansaglam/tepkin) — Reactive MongoDB Driver for Scala built on top of Akka IO and Akka Streams.
+* [*Activate ★ 249 ⧗ 4*](https://github.com/fwbrasil/activate) - Pluggable object persistence in Scala.
+* [*doobie ★ 263 ⧗ 1*](https://github.com/tpolecat/doobie) - Pure functional JDBC layer for Scala.
+* [*Elastic4s ★ 401 ⧗ 0*](https://github.com/sksamuel/elastic4s) - A scala DSL / reactive client for Elasticsearch
+* [*MapperDao ★ 2 ⧗ 75*](https://github.com/kostaskougios/mapperdao) - An ORM library for oracle, mysql, mssql, and postgresql
+* [*Phantom ★ 278 ⧗ 0*](https://github.com/websudos/phantom) - Reactive type safe Scala driver for Apache Cassandra.
+* [*PostgreSQL and MySQL async ★ 647 ⧗ 0*](https://github.com/mauricio/postgresql-async) - Async database drivers to talk to PostgreSQL and MySQL in Scala.
+* [ReactiveCouchbase ★ ? ⧗ ?](http://reactivecouchbase.org/) - Reactive Scala Driver for Couchbase. Also includes a Play plug-in. An official plug-in is also in development.
+* [*ReactiveMongo ★ 573 ⧗ 3*](https://github.com/ReactiveMongo/ReactiveMongo) - Reactive Scala Driver for MongoDB.
+* [*ReactiveNeo ★ 21 ⧗ 1*](https://github.com/websudos/reactiveneo) - Reactive type-safe Scala driver for Neo4J.
+* [Salat ★ ? ⧗ ?](https://github.com/novus/salat/) - ORM for MongoDB. A related Play-plugin is also available.
+* [*Scala ActiveRecord ★ 229 ⧗ 3*](https://github.com/aselab/scala-activerecord) - ORM library for scala, inspired by ActiveRecord of Ruby on Rails.
+* [*ScalikeJDBC ★ 474 ⧗ 1*](https://github.com/scalikejdbc/scalikejdbc) - A tidy SQL-based DB access library for Scala developers.
+* [*Slick ★ 1261 ⧗ 0*](https://github.com/slick/slick) - Modern database query and access library for Scala.
+* [*Sorm ★ 178 ⧗ 2*](https://github.com/sorm/sorm) - A functional boilerplate-free Scala ORM.
+* [*Squeryl ★ 439 ⧗ 2*](https://github.com/squeryl/squeryl) - A Scala DSL for talking with databases with minimum verbosity and maximum type safety.
+* [*Tepkin ★ 81 ⧗ 5*](https://github.com/fehmicansaglam/tepkin) - Reactive MongoDB Driver for Scala built on top of Akka IO and Akka Streams.
 
 ## Graphical User Interfaces
 
 *Libraries for creation of graphical user interfaces*
 
-* [ScalaFX](http://www.scalafx.org/) - Scala DSL for creating Graphical User Interfaces that sits on top of JavaFX.
+* [ScalaFX ★ ? ⧗ ?](http://www.scalafx.org/) - Scala DSL for creating Graphical User Interfaces that sits on top of JavaFX.
 
 ## Web Frameworks
 
 *Scala frameworks for web development.*
 
-* [Play](https://github.com/playframework/playframework) — Makes it easy to build scalable, fast and real-time web applications with Java & Scala.
-* [Lift](https://github.com/lift/framework) — Secure and powerful full stack web framework ([discussion](https://github.com/lauris/awesome-scala/pull/19)).
-* [Skinny Framework](https://github.com/skinny-framework/skinny-framework) — A full-stack web app framework upon Scalatra for rapid Development in Scala.
-* [Scalatra](https://github.com/scalatra/scalatra) — Tiny Scala high-performance, async web framework, inspired by Sinatra.
-* [Spray](https://github.com/spray/spray) — A suite of scala libraries for building and consuming RESTful web services on top of Akka.
-* [Finatra](https://github.com/twitter/finatra) — A sinatra-inspired web framework for scala, running on top of Finagle.
-* [Reactive](https://github.com/nafg/reactive) — FRP and web abstractions, which can be plugged into any web framework (currently only has bindings for Lift).
-* [Chaos](https://github.com/mesosphere/chaos) — A lightweight framework for writing REST services in Scala.
-* [Xitrum](http://xitrum-framework.github.io/) — An async and clustered Scala web framework and HTTP(S) server fusion on top of Netty, Akka, and Hazelcast.
-* [Unfiltered](https://github.com/unfiltered/unfiltered) — A modular set of unopinionated primitives for servicing HTTP and WebSocket requests in Scala.
-* [Colossus](http://tumblr.github.io/colossus/) — lightweight framework for building high-performance applications in Scala that require non-blocking network I/O.
-* [Socko](http://sockoweb.org/) — An embedded Scala web server powered by Netty networking and Akka processing.
+* [*Chaos ★ 141 ⧗ 3*](https://github.com/mesosphere/chaos) - A lightweight framework for writing REST services in Scala.
+* [Colossus ★ ? ⧗ ?](http://tumblr.github.io/colossus/) - lightweight framework for building high-performance applications in Scala that require non-blocking network I/O.
+* [*Finatra ★ 840 ⧗ 0*](https://github.com/twitter/finatra) - A sinatra-inspired web framework for scala, running on top of Finagle.
+* [*Lift ★ 905 ⧗ 2*](https://github.com/lift/framework) - Secure and powerful full stack web framework ([discussion](https://github.com/lauris/awesome-scala/pull/19)).
+* [*Play ★ 6561 ⧗ 0*](https://github.com/playframework/playframework) - Makes it easy to build scalable, fast and real-time web applications with Java & Scala.
+* [*Reactive ★ 187 ⧗ 34*](https://github.com/nafg/reactive) - FRP and web abstractions, which can be plugged into any web framework (currently only has bindings for Lift).
+* [*Scalatra ★ 1705 ⧗ 0*](https://github.com/scalatra/scalatra) - Tiny Scala high-performance, async web framework, inspired by Sinatra.
+* [*Skinny Framework ★ 434 ⧗ 0*](https://github.com/skinny-framework/skinny-framework) - A full-stack web app framework upon Scalatra for rapid Development in Scala.
+* [Socko ★ ? ⧗ ?](http://sockoweb.org/) - An embedded Scala web server powered by Netty networking and Akka processing.
+* [*Spray ★ 2003 ⧗ 0*](https://github.com/spray/spray) - A suite of scala libraries for building and consuming RESTful web services on top of Akka.
+* [*Unfiltered ★ 592 ⧗ 0*](https://github.com/unfiltered/unfiltered) - A modular set of unopinionated primitives for servicing HTTP and WebSocket requests in Scala.
+* [Xitrum ★ ? ⧗ ?](http://xitrum-framework.github.io/) - An async and clustered Scala web framework and HTTP(S) server fusion on top of Netty, Akka, and Hazelcast.
 
 ## i18n
 
 *Scala libraries for i18n.*
 
-* [Scaposer](https://github.com/xitrum-framework/scaposer) – GNU Gettext .po file loader for Scala.
-* [scala-xgettext](https://github.com/xitrum-framework/scala-xgettext) – A compiler plugin that acts like GNU xgettext command to extract i18n strings in Scala source code files to Gettext .po file.
+* [*scala-xgettext ★ 13 ⧗ 53*](https://github.com/xitrum-framework/scala-xgettext) - A compiler plugin that acts like GNU xgettext command to extract i18n strings in Scala source code files to Gettext .po file.
+* [*Scaposer ★ 24 ⧗ 10*](https://github.com/xitrum-framework/scaposer) - GNU Gettext .po file loader for Scala.
 
 ## Authentication
 
 *Libraries for implementing authentications schemes.*
 
-* [scala-oauth2-provider](https://github.com/nulab/scala-oauth2-provider) — OAuth 2.0 server-side implementation written in Scala.
-* [SecureSocial](https://github.com/jaliss/securesocial) — A module that provides OAuth, OAuth2 and OpenID authentication for Play Framework applications.
-* [play2-auth](https://github.com/t2v/play2-auth) — Play2.x Authentication and Authorization module.
-* [play-pac4j](https://github.com/leleuj/play-pac4j) — Profile & Authentication Client in Scala for CAS, OAuth, OpenID, SAML & HTTP protocols and Play 2.x framework.
-* [play-silhouette](https://github.com/mohiva/play-silhouette) — Authentication library for Play Framework applications that supports several authentication methods, including OAuth1, OAuth2, OpenID, Credentials or custom authentication schemes.
+* [*play-pac4j ★ 6 ⧗ 11*](https://github.com/leleuj/play-pac4j) - Profile & Authentication Client in Scala for CAS, OAuth, OpenID, SAML & HTTP protocols and Play 2.x framework.
+* [*play-silhouette ★ 327 ⧗ 0*](https://github.com/mohiva/play-silhouette) - Authentication library for Play Framework applications that supports several authentication methods, including OAuth1, OAuth2, OpenID, Credentials or custom authentication schemes.
+* [*play2-auth ★ 478 ⧗ 2*](https://github.com/t2v/play2-auth) - Play2.x Authentication and Authorization module.
+* [*scala-oauth2-provider ★ 226 ⧗ 3*](https://github.com/nulab/scala-oauth2-provider) - OAuth 2.0 server-side implementation written in Scala.
+* [*SecureSocial ★ 1105 ⧗ 2*](https://github.com/jaliss/securesocial) - A module that provides OAuth, OAuth2 and OpenID authentication for Play Framework applications.
 
 ## Testing
 
 *Libraries for code testing.*
 
-* [ScalaCheck](https://github.com/rickynils/scalacheck) — Property-based testing for Scala.
-* [ScalaTest](https://github.com/scalatest/scalatest) — A testing tool for Scala and Java developers.
-* [ScalaMeter](https://scalameter.github.io/) - Performance &  memory footprint measuring, regression testing.
-* [Specs2](https://github.com/etorreborre/specs2) — Software Specifications for Scala.
-* [µTest](https://github.com/lihaoyi/utest) — A tiny, portable testing library for Scala.
-* [Scalive](https://github.com/xitrum-framework/scalive) — Connect a Scala REPL to running JVM processes without any prior setup; this library is used for inspecting systems in production mode.
-* [Gatling](http://gatling-tool.org/) – Async Scala-Akka-Netty based Stress Tool.
-* [ScalaMock](http://scalamock.org) – Scala native mocking framework
+* [Gatling ★ ? ⧗ ?](http://gatling-tool.org/) - Async Scala-Akka-Netty based Stress Tool.
+* [*ScalaCheck ★ 832 ⧗ 1*](https://github.com/rickynils/scalacheck) - Property-based testing for Scala.
+* [ScalaMeter ★ ? ⧗ ?](https://scalameter.github.io/) - Performance &  memory footprint measuring, regression testing.
+* [ScalaMock ★ ? ⧗ ?](http://scalamock.org) - Scala native mocking framework
+* [*ScalaTest ★ 269 ⧗ 2*](https://github.com/scalatest/scalatest) - A testing tool for Scala and Java developers.
+* [*Scalive ★ 114 ⧗ 29*](https://github.com/xitrum-framework/scalive) - Connect a Scala REPL to running JVM processes without any prior setup; this library is used for inspecting systems in production mode.
+* [*Specs2 ★ 443 ⧗ 0*](https://github.com/etorreborre/specs2) - Software Specifications for Scala.
+* [*µTest ★ 117 ⧗ 4*](https://github.com/lihaoyi/utest) - A tiny, portable testing library for Scala.
 
 ## JSON Manipulation
 
 *Libraries for work with json.*
 
-* [json4s](https://github.com/json4s/json4s) — Project aims to provide a single AST to be used by other scala json libraries.
-* [spray-json](https://github.com/spray/spray-json) — Lightweight, clean and efficient JSON implementation in Scala.
-* [argonaut](http://argonaut.io/) — Purely Functional JSON in Scala.
-* [jackson-module-scala](https://github.com/FasterXML/jackson-module-scala) — Add-on module for Jackson to support Scala-specific datatypes.
-* [play-json](https://github.com/playframework/playframework/tree/master/framework/src/play-json) — Flexible and powerful JSON manipulation, validation and serialization, with no reflection at runtime.
-* [scalajack](https://github.com/gzoller/ScalaJack) - Fast 'n easy JSON serialization with optional MongoDB support.  Uses Jackson under the hood.
+* [argonaut ★ ? ⧗ ?](http://argonaut.io/) - Purely Functional JSON in Scala.
+* [*jackson-module-scala ★ 224 ⧗ 8*](https://github.com/FasterXML/jackson-module-scala) - Add-on module for Jackson to support Scala-specific datatypes.
+* [*json4s ★ 467 ⧗ 1*](https://github.com/json4s/json4s) - Project aims to provide a single AST to be used by other scala json libraries.
+* [play-json ★ ? ⧗ ?](https://github.com/playframework/playframework/tree/master/framework/src/play-json) - Flexible and powerful JSON manipulation, validation and serialization, with no reflection at runtime.
+* [*scalajack ★ 62 ⧗ 4*](https://github.com/gzoller/ScalaJack) - Fast 'n easy JSON serialization with optional MongoDB support.  Uses Jackson under the hood.
+* [*spray-json ★ 403 ⧗ 2*](https://github.com/spray/spray-json) - Lightweight, clean and efficient JSON implementation in Scala.
 
 ## Serialization
 
 *Libraries for serializing and deserializing data for storage or transport.*
 
-* [Pickling](https://github.com/scala/pickling) — Fast, customizable, boilerplate-free pickling support.
-* [scodec](https://github.com/scodec/scodec) — A combinator library for working with binary data.
-* [Scrooge](http://twitter.github.io/scrooge/) — An Apache Thrift code generator for Scala.
-* [validation](https://github.com/jto/validation) — Advanced validation & serialization for JSON, HTML form data, etc, with no reflection at runtime.
-* [Chill](https://github.com/twitter/chill) — Extensions for the Kryo serialization library to ease configuration in systems like Hadoop and Storm.
-* [µPickle](http://lihaoyi.github.io/upickle-pprint/upickle/) — A lightweight serialization library for Scala that works in ScalaJS, allowing transfer of structured data between the JVM and JavaScript.
-* [ScalaPB](http://trueaccord.github.io/ScalaPB/) - A Protocol Buffer generator for Scala.
+* [*Chill ★ 285 ⧗ 6*](https://github.com/twitter/chill) - Extensions for the Kryo serialization library to ease configuration in systems like Hadoop and Storm.
+* [*Pickling ★ 632 ⧗ 1*](https://github.com/scala/pickling) - Fast, customizable, boilerplate-free pickling support.
+* [ScalaPB ★ ? ⧗ ?](http://trueaccord.github.io/ScalaPB/) - A Protocol Buffer generator for Scala.
+* [*scodec ★ 301 ⧗ 4*](https://github.com/scodec/scodec) - A combinator library for working with binary data.
+* [Scrooge ★ ? ⧗ ?](http://twitter.github.io/scrooge/) - An Apache Thrift code generator for Scala.
+* [*validation ★ 101 ⧗ 7*](https://github.com/jto/validation) - Advanced validation & serialization for JSON, HTML form data, etc, with no reflection at runtime.
+* [µPickle ★ ? ⧗ ?](http://lihaoyi.github.io/upickle-pprint/upickle/) - A lightweight serialization library for Scala that works in ScalaJS, allowing transfer of structured data between the JVM and JavaScript.
 
 ## Science and Data Analysis
 
 *Libraries for scientific computing, data analysis and numerical processing.*
 
-* [Algebird](https://github.com/twitter/algebird) — Abstract Algebra for Scala.
-* [Axle](http://axle-lang.org) — Spire-based DSL for scientific cloud computing.
-* [Breeze](https://github.com/scalanlp/breeze) — Breeze is a numerical processing library for Scala.
-* [Chalk](https://github.com/scalanlp/chalk) — Chalk is a natural language processing library.
-* [FACTORIE](https://github.com/factorie/factorie) — A toolkit for deployable probabilistic modeling, implemented as a software library in Scala.
-* [Figaro](https://github.com/p2t2/figaro) - Figaro is a probabilistic programming language that supports development of very rich probabilistic models.
-* [MGO](https://github.com/romainreuillon/mgo) — Modular multi-objective evolutionary algorithm optimization library enforcing immutability.
-* [MLLib](https://spark.apache.org/mllib/) — Machine Learning framework for Spark
-* [OpenMOLE](https://github.com/ISCPIF/openmole) — OpenMOLE (Open MOdeL Experiment) is a workflow engine designed to leverage the computing power of distributed execution environments for naturally parallel processes.
-* [Saddle](https://github.com/saddle/saddle) — A minimalist port of Pandas to Scala
-* [Spire](https://github.com/non/spire) — Powerful new number types and numeric abstractions for Scala.
-* [Squants](https://github.com/garyKeorkunian/squants) — The Scala API for Quantities, Units of Measure and Dimensional Analysis.
-* [PredictionIO](https://github.com/PredictionIO/PredictionIO) - machine learning server for developers and data scientists. Built on Apache Spark, HBase and Spray
-
+* [*Algebird ★ 955 ⧗ 0*](https://github.com/twitter/algebird) - Abstract Algebra for Scala.
+* [Axle ★ ? ⧗ ?](http://axle-lang.org) - Spire-based DSL for scientific cloud computing.
+* [*Breeze ★ 1087 ⧗ 0*](https://github.com/scalanlp/breeze) - Breeze is a numerical processing library for Scala.
+* [*Chalk ★ 165 ⧗ 0*](https://github.com/scalanlp/chalk) - Chalk is a natural language processing library.
+* [*FACTORIE ★ 322 ⧗ 4*](https://github.com/factorie/factorie) - A toolkit for deployable probabilistic modeling, implemented as a software library in Scala.
+* [*Figaro ★ 201 ⧗ 8*](https://github.com/p2t2/figaro) - Figaro is a probabilistic programming language that supports development of very rich probabilistic models.
+* [*MGO ★ 9 ⧗ 96*](https://github.com/romainreuillon/mgo) - Modular multi-objective evolutionary algorithm optimization library enforcing immutability.
+* [MLLib ★ ? ⧗ ?](https://spark.apache.org/mllib/) - Machine Learning framework for Spark
+* [*OpenMOLE ★ 9 ⧗ 28*](https://github.com/ISCPIF/openmole) - OpenMOLE (Open MOdeL Experiment) is a workflow engine designed to leverage the computing power of distributed execution environments for naturally parallel processes.
+* [*PredictionIO ★ 7422 ⧗ 0*](https://github.com/PredictionIO/PredictionIO) - machine learning server for developers and data scientists. Built on Apache Spark, HBase and Spray
+* [*Saddle ★ 324 ⧗ 8*](https://github.com/saddle/saddle) - A minimalist port of Pandas to Scala
+* [*Spire ★ 737 ⧗ 4*](https://github.com/non/spire) - Powerful new number types and numeric abstractions for Scala.
+* [*Squants ★ 206 ⧗ 0*](https://github.com/garyKeorkunian/squants) - The Scala API for Quantities, Units of Measure and Dimensional Analysis.
 
 ## Big Data
-* [Spark](http://spark.apache.org/) — Lightning fast cluster computing — up to 100x faster than Hadoop for iterative algorithms (memory caching) and up to 10x faster than Hadoop for single-pass MapReduce jobs. Compatible with YARN-enabled Hadoop clusters, can run on Mesos and in stand-alone mode as well.
-* [Scalding](https://github.com/twitter/scalding) — A Scala binding for the Cascading abstraction of Hadoop MapReduce.
-* [Summingbird](https://github.com/twitter/summingbird) — An implementation of the “lambda architecture” as a software abstraction — a single API for Hadoop and Storm.
-* [Shadoop](https://github.com/adamretter/shadoop) - A Scala DSL for Hadoop MapReduce.
-* [Scrunch](http://crunch.apache.org/scrunch.html) — A Scala wrapper for [Apache Crunch](http://crunch.apache.org/index.html) which provides a framework for writing, testing, and running MapReduce pipelines.
-* [GridScale](https://github.com/romainreuillon/gridscale) — A Scala API for computing clusters and grids.
-* [BIDMach](https://github.com/BIDData/BIDMach) - CPU and GPU machine learning library, using JNI for GPU computation.
-* [scoozie](https://github.com/klout/scoozie) — Scala DSL on top of Oozie XML.
+
 * [Scoobi] (https://github.com/nicta/scoobi) - Write type-safe Hadoop programs in idiomatic Scala way
-* [Gearpump](https://github.com/intel-hadoop/gearpump) - Lightweight real-time big data streaming engine
+
+* [*BIDMach ★ 395 ⧗ 0*](https://github.com/BIDData/BIDMach) - CPU and GPU machine learning library, using JNI for GPU computation.
+* [*Gearpump ★ 314 ⧗ 1*](https://github.com/intel-hadoop/gearpump) - Lightweight real-time big data streaming engine
+* [*GridScale ★ 7 ⧗ 4*](https://github.com/romainreuillon/gridscale) - A Scala API for computing clusters and grids.
+* [*Scalding ★ 2184 ⧗ 1*](https://github.com/twitter/scalding) - A Scala binding for the Cascading abstraction of Hadoop MapReduce.
+* [*scoozie ★ 47 ⧗ 4*](https://github.com/klout/scoozie) - Scala DSL on top of Oozie XML.
+* [Scrunch ★ ? ⧗ ?](http://crunch.apache.org/scrunch.html) - A Scala wrapper for [Apache Crunch](http://crunch.apache.org/index.html) which provides a framework for writing, testing, and running MapReduce pipelines.
+* [*Shadoop ★ 7 ⧗ 134*](https://github.com/adamretter/shadoop) - A Scala DSL for Hadoop MapReduce.
+* [Spark ★ ? ⧗ ?](http://spark.apache.org/) - Lightning fast cluster computing — up to 100x faster than Hadoop for iterative algorithms (memory caching) and up to 10x faster than Hadoop for single-pass MapReduce jobs. Compatible with YARN-enabled Hadoop clusters, can run on Mesos and in stand-alone mode as well.
+* [*Summingbird ★ 1522 ⧗ 1*](https://github.com/twitter/summingbird) - An implementation of the “lambda architecture” as a software abstraction — a single API for Hadoop and Storm.
 
 ## Functional Reactive Programming
 
 *Event streams, signals, observables, etc.*
 
-* [Scala.Rx](https://github.com/lihaoyi/scala.rx) — An experimental library for Functional Reactive Programming in Scala (reactive variables). Scala.js compatible.
-* [scala.frp](https://github.com/dylemma/scala.frp) — Functional Reactive Programming for Scala (event streams).
-* [RxScala](https://github.com/ReactiveX/RxScala) — Reactive Extensions for Scala – a library for composing asynchronous and event-based programs using observable sequences
-* [Reactive Collections](https://github.com/storm-enroute/reactive-collections) – A library that incorporates event streams and signals with specialized collections called reactive containers, and expresses concurrency using isolates and channels.
-* [Vertx.io](http://vertx.io/) – A polyglot reactive application platform for the JVM which aims to be an alternative to node.js. Its concurrency model resembles actors. It supports [Scala](http://vertx.io/core_manual_scala.html), Clojure, Java, Javascript, Ruby, Groovy and Python.
-* [Monifu](https://github.com/monifu/monifu) — Extensions to Scala’s standard library for multi-threading primitives and functional reactive programming. Scala.js compatible.
+* [*Monifu ★ 147 ⧗ 4*](https://github.com/monifu/monifu) - Extensions to Scala’s standard library for multi-threading primitives and functional reactive programming. Scala.js compatible.
+* [*Reactive Collections ★ 71 ⧗ 34*](https://github.com/storm-enroute/reactive-collections) - A library that incorporates event streams and signals with specialized collections called reactive containers, and expresses concurrency using isolates and channels.
+* [*RxScala ★ 280 ⧗ 0*](https://github.com/ReactiveX/RxScala) - Reactive Extensions for Scala – a library for composing asynchronous and event-based programs using observable sequences
+* [*scala.frp ★ 17 ⧗ 112*](https://github.com/dylemma/scala.frp) - Functional Reactive Programming for Scala (event streams).
+* [*Scala.Rx ★ 518 ⧗ 3*](https://github.com/lihaoyi/scala.rx) - An experimental library for Functional Reactive Programming in Scala (reactive variables). Scala.js compatible.
+* [Vertx.io ★ ? ⧗ ?](http://vertx.io/) - A polyglot reactive application platform for the JVM which aims to be an alternative to node.js. Its concurrency model resembles actors. It supports [Scala](http://vertx.io/core_manual_scala.html), Clojure, Java, Javascript, Ruby, Groovy and Python.
 
 ## Modularization and Dependency Injection
 
 *Modularization of applications, dependency injection, etc.*
 
-* [Domino](https://github.com/helgoboss/domino) — Write elegant OSGi bundle activators in Scala.
-* [Sclasner](https://github.com/xitrum-framework/sclasner) - Scala classpath scanner.
-* [Scaldi](https://github.com/scaldi/scaldi) — Lightweight Scala Dependency Injection Library.
-* [MacWire](https://github.com/adamw/macwire) — Scala Macro to generate wiring code for class instantiation. DI container replacement.
-* [SubCut](https://github.com/dickwall/subcut) — Scala Uniquely Bound Classes Under Traits.
+* [*Domino ★ 27 ⧗ 0*](https://github.com/helgoboss/domino) - Write elegant OSGi bundle activators in Scala.
+* [*MacWire ★ 342 ⧗ 2*](https://github.com/adamw/macwire) - Scala Macro to generate wiring code for class instantiation. DI container replacement.
+* [*Scaldi ★ 171 ⧗ 2*](https://github.com/scaldi/scaldi) - Lightweight Scala Dependency Injection Library.
+* [*Sclasner ★ 7 ⧗ 163*](https://github.com/xitrum-framework/sclasner) - Scala classpath scanner.
+* [*SubCut ★ 377 ⧗ 15*](https://github.com/dickwall/subcut) - Scala Uniquely Bound Classes Under Traits.
 
 ## Distributed Systems
 
 *Libraries and frameworks for writing distributed applications.*
 
-* [Akka](http://akka.io/) — A toolkit and runtime for building highly concurrent, distributed, and fault tolerant event-driven applications.
-* [Finagle](https://twitter.github.io/finagle/) — An extensible, protocol-agnostic RPC system designed for high performance and concurrency.
-* [Glokka](https://github.com/xitrum-framework/glokka) - Library to register and lookup actors by names in an Akka cluster.
+* [Akka ★ ? ⧗ ?](http://akka.io/) - A toolkit and runtime for building highly concurrent, distributed, and fault tolerant event-driven applications.
+* [Finagle ★ ? ⧗ ?](https://twitter.github.io/finagle/) - An extensible, protocol-agnostic RPC system designed for high performance and concurrency.
+* [*Glokka ★ 35 ⧗ 9*](https://github.com/xitrum-framework/glokka) - Library to register and lookup actors by names in an Akka cluster.
 
 ## Extensions
 
 *Scala extensions.*
 
-* [Scalaz](https://github.com/scalaz/scalaz) — An extension to the core Scala library for functional programming.
-* [Shapeless](https://github.com/milessabin/shapeless) — A type class and dependent type based generic programming library for Scala.
-* [Twitter Util](https://github.com/twitter/util) — General-purpose Scala libraries, including a future implementation and other concurrency tools.
-* [Scala Async](https://github.com/scala/async) — An asynchronous programming facility for Scala.
-* [Resolvable](https://github.com/resolvable/resolvable) — A library to optimize fetching immutable data structures from several endpoints in several formats.
-* [Scala Blitz](http://scala-blitz.github.io/) – A library to speed up Scala collection operations by removing runtime overheads during compilation, and a custom data-parallel operation runtime.
-* [Log4s](http://log4s.org) - Fast, Scala-friendly logging bindings on top of [SLF4J](http://slf4j.org/). Uses macros for extreme performance.
-* [Lamma](https://github.com/maxcellent/lamma) – A Scala date library for date and schedule generation.
-* [Scala Graph](http://www.scala-graph.org/) – A Scala library with basic graph functionality that seamlessly fits into the Scala standard collections library.
-* [Cassovary](https://github.com/twitter/cassovary) – A Scala library that is designed from the ground up for space efficiency, handling graphs with billions of nodes and edges.
-* [Scalactic](http://www.scalactic.org/) - Small library of utilities related to quality that helps keeping code clear and correct.
+* [*Cassovary ★ 737 ⧗ 0*](https://github.com/twitter/cassovary) - A Scala library that is designed from the ground up for space efficiency, handling graphs with billions of nodes and edges.
+* [*Lamma ★ 42 ⧗ 4*](https://github.com/maxcellent/lamma) - A Scala date library for date and schedule generation.
+* [Log4s ★ ? ⧗ ?](http://log4s.org) - Fast, Scala-friendly logging bindings on top of [SLF4J](http://slf4j.org/). Uses macros for extreme performance.
+* [*Resolvable ★ 24 ⧗ 15*](https://github.com/resolvable/resolvable) - A library to optimize fetching immutable data structures from several endpoints in several formats.
+* [*Scala Async ★ 514 ⧗ 0*](https://github.com/scala/async) - An asynchronous programming facility for Scala.
+* [Scala Blitz ★ ? ⧗ ?](http://scala-blitz.github.io/) - A library to speed up Scala collection operations by removing runtime overheads during compilation, and a custom data-parallel operation runtime.
+* [Scala Graph ★ ? ⧗ ?](http://www.scala-graph.org/) - A Scala library with basic graph functionality that seamlessly fits into the Scala standard collections library.
+* [Scalactic ★ ? ⧗ ?](http://www.scalactic.org/) - Small library of utilities related to quality that helps keeping code clear and correct.
+* [*Scalaz ★ 1979 ⧗ 0*](https://github.com/scalaz/scalaz) - An extension to the core Scala library for functional programming.
+* [*Shapeless ★ 1164 ⧗ 0*](https://github.com/milessabin/shapeless) - A type class and dependent type based generic programming library for Scala.
+* [*Twitter Util ★ 1223 ⧗ 0*](https://github.com/twitter/util) - General-purpose Scala libraries, including a future implementation and other concurrency tools.
 
 ## Misc
 
-* [REPLesent](https://github.com/marconilanna/REPLesent) – A presentation tool built inside the Scala REPL. Runs code straight from your slides with a single keystroke.
+* [*REPLesent ★ 148 ⧗ 0*](https://github.com/marconilanna/REPLesent) - A presentation tool built inside the Scala REPL. Runs code straight from your slides with a single keystroke.
 
 ## Android
 
 *Scala libraries and wrappers for Android development.*
 
-* [Scaloid](https://github.com/pocorall/scaloid) — Less painful Android development with Scala.
-* [Macroid](https://github.com/macroid/macroid) — A modular functional UI language for Android.
-* [Android SDK Plugin for SBT](https://github.com/pfn/android-sdk-plugin) — An sbt plugin that adds tasks for developing Android applications.
-* [Gradle Android Scala Plugin](https://github.com/saturday06/gradle-android-scala-plugin) - A gradle plugin that allows you to use Scala with Android
+* [*Android SDK Plugin for SBT ★ 347 ⧗ 0*](https://github.com/pfn/android-sdk-plugin) - An sbt plugin that adds tasks for developing Android applications.
+* [*Gradle Android Scala Plugin ★ 205 ⧗ 1*](https://github.com/saturday06/gradle-android-scala-plugin) - A gradle plugin that allows you to use Scala with Android
+* [*Macroid ★ 279 ⧗ 0*](https://github.com/macroid/macroid) - A modular functional UI language for Android.
+* [*Scaloid ★ 1671 ⧗ 0*](https://github.com/pocorall/scaloid) - Less painful Android development with Scala.
 
 ## HTTP
 
 *Scala libraries and wrappers for HTTP clients.*
 
-* [Dispatch](https://github.com/dispatch/reboot) — Library for asynchronous HTTP interaction. It provides a Scala vocabulary for Java’s [async-http-client](https://github.com/AsyncHttpClient/async-http-client).
-* [Netcaty](https://github.com/ngocdaothanh/netcaty) - Simple net test client/server for Netty and Scala lovers.
-* [Scalaxb](https://github.com/eed3si9n/scalaxb) — An XML data-binding tool for Scala that supports W3C XML Schema (xsd) and Web Services Description Language (wsdl) as the input file.
-* [Spray](http://spray.io/) — Actor-based library for http interaction.
-* [Tubesocks](https://github.com/softprops/tubesocks) — Library supporting bi-directional communication with websocket servers.
-* [scalaj-http](https://github.com/scalaj/scalaj-http) – Simple scala wrapper for HttpURLConnection (including OAuth support).
-* [Finch.io](https://github.com/finagle/finch) — Purely Functional REST API atop of [Finagle](https://github.com/twitter/finagle).
-* [Newman](https://github.com/stackmob/newman) — A REST DSL that tries to take the best from Dispatch, Finagle and Apache HttpClient. See [here](https://www.paypal-engineering.com/2014/02/13/hello-newman-a-rest-client-for-scala/) for rationale.
-
+* [*Dispatch ★ 293 ⧗ 1*](https://github.com/dispatch/reboot) - Library for asynchronous HTTP interaction. It provides a Scala vocabulary for Java’s [async-http-client](https://github.com/AsyncHttpClient/async-http-client).
+* [*Finch.io ★ 364 ⧗ 1*](https://github.com/finagle/finch) - Purely Functional REST API atop of [Finagle](https://github.com/twitter/finagle).
+* [*Netcaty ★ 9 ⧗ 30*](https://github.com/ngocdaothanh/netcaty) - Simple net test client/server for Netty and Scala lovers.
+* [*Newman ★ 205 ⧗ 24*](https://github.com/stackmob/newman) - A REST DSL that tries to take the best from Dispatch, Finagle and Apache HttpClient. See [here](https://www.paypal-engineering.com/2014/02/13/hello-newman-a-rest-client-for-scala/) for rationale.
+* [*scalaj-http ★ 274 ⧗ 1*](https://github.com/scalaj/scalaj-http) - Simple scala wrapper for HttpURLConnection (including OAuth support).
+* [*Scalaxb ★ 171 ⧗ 5*](https://github.com/eed3si9n/scalaxb) - An XML data-binding tool for Scala that supports W3C XML Schema (xsd) and Web Services Description Language (wsdl) as the input file.
+* [Spray ★ ? ⧗ ?](http://spray.io/) - Actor-based library for http interaction.
+* [*Tubesocks ★ 7 ⧗ 374*](https://github.com/softprops/tubesocks) - Library supporting bi-directional communication with websocket servers.
 
 ## Semantic Web
 
 *Scala libraries for interactions with the Web of Data, and other RDF tools.*
 
-* [Banana-RDF](https://github.com/w3c/banana-rdf) – Scala-friendly abstractions for RDF and Linked Data technologies. Supports Jena, Sesame and native Scala.
+* [*Banana-RDF ★ 153 ⧗ 1*](https://github.com/w3c/banana-rdf) - Scala-friendly abstractions for RDF and Linked Data technologies. Supports Jena, Sesame and native Scala.
 
 ## Metrics and Monitoring
 
 *Scala libraries for gathering metrics and monitoring applications.*
 
-* [Kamon](http://kamon.io) - Gathering metrics from applications built with Akka, Spray and Play! with support for user metrics as well.
+* [Kamon ★ ? ⧗ ?](http://kamon.io) - Gathering metrics from applications built with Akka, Spray and Play! with support for user metrics as well.
 
 ## Parsing
 
 *Scala libraries for creating parsers.*
 
-* [Scala Parser Combinators](https://github.com/scala/scala-parser-combinators) – Scala Standard Parser Combinator Library.
-* [Parboiled2](https://github.com/sirthias/parboiled2) – A Fast Parser Generator for Scala 2.10.3+.
-* [atto](https://github.com/tpolecat/atto) - Pure functional incremental text parsing library for Scala, based on Attoparsec.
+* [*atto ★ 57 ⧗ 6*](https://github.com/tpolecat/atto) - Pure functional incremental text parsing library for Scala, based on Attoparsec.
+* [*Parboiled2 ★ 343 ⧗ 0*](https://github.com/sirthias/parboiled2) - A Fast Parser Generator for Scala 2.10.3+.
+* [*Scala Parser Combinators ★ 78 ⧗ 0*](https://github.com/scala/scala-parser-combinators) - Scala Standard Parser Combinator Library.
 
 ## Sbt plugins
 
 *Sbt plugins to make your life easier.*
 
-* [Sbt-Revolver](https://github.com/spray/sbt-revolver) – Fork & Stop processes from sbt.
-* [Sbt-Eclipse](https://github.com/typesafehub/sbteclipse) – Create Eclipse project definitions from sbt builds.
-* [Sbt-Idea](https://github.com/mpeltonen/sbt-idea) – Create IntelliJ IDEA project definitions from sbt builds (not needed from IntelliJ 14, it supports sbt/scala projects through the Scala plugin).
-* [Sbt-Native-Packager](https://github.com/sbt/sbt-native-packager) – Bundle up Scala software for native packaging systems, like deb, rpm, homebrew, msi..
-* [Sbt-Dependency-Graph](https://github.com/jrudolph/sbt-dependency-graph) – Create a dependency graph for your project.
-* [Sbt-Versions](https://github.com/sksamuel/sbt-versions) - Plugin that checks for updated versions of your project's dependencies.
-* [Sbt-One-Jar](https://github.com/sbt/sbt-onejar) – Packages your project using One-JAR™.
-* [Sbt-Start-Script](https://github.com/sbt/sbt-start-script) – Create a "start" script to run the program.
-* [Sbt-Sublime](https://github.com/orrsella/sbt-sublime) – Create Sublime Text projects with library dependencies sources
-* [ScalaKata](https://github.com/MasseGuillaume/ScalaKata) – Scala playground & Documentation tool.
-* [Zeppelin](http://zeppelin-project.org/) - Scala and Spark Notebook (like IPython Notebook)
-* [xsbt-web-plugin](https://github.com/earldouglas/xsbt-web-plugin) – Build enterprise J2EE Web applications in Scala.
-* [tut](https://github.com/tpolecat/tut) - Tool for writing documentation with typechecked examples.
-* [sbt-ide-settings](https://github.com/Jetbrains/sbt-ide-settings) - SBT plugin for tweaking various IDE settings
-* [Sbt-BuildInfo](https://github.com/sbt/sbt-buildinfo) – Generates Scala source from build definition.
-* [Sbt-Updates](https://github.com/rtimush/sbt-updates) – Shows sbt project's dependency updates.
-* [sbt-pack](https://github.com/xerial/sbt-pack) - A sbt plugin for creating distributable Scala packages.
-* [Ammonite](http://lihaoyi.github.io/Ammonite/) - Ammonite is a collection of Scala libraries intended to improve the experience of using Scala as an system shell.
+* [Ammonite ★ ? ⧗ ?](http://lihaoyi.github.io/Ammonite/) - Ammonite is a collection of Scala libraries intended to improve the experience of using Scala as an system shell.
+* [*Sbt-BuildInfo ★ 151 ⧗ 2*](https://github.com/sbt/sbt-buildinfo) - Generates Scala source from build definition.
+* [*Sbt-Dependency-Graph ★ 359 ⧗ 0*](https://github.com/jrudolph/sbt-dependency-graph) - Create a dependency graph for your project.
+* [*Sbt-Eclipse ★ 487 ⧗ 3*](https://github.com/typesafehub/sbteclipse) - Create Eclipse project definitions from sbt builds.
+* [*sbt-ide-settings ★ 15 ⧗ 1*](https://github.com/Jetbrains/sbt-ide-settings) - SBT plugin for tweaking various IDE settings
+* [*Sbt-Idea ★ 940 ⧗ 0*](https://github.com/mpeltonen/sbt-idea) - Create IntelliJ IDEA project definitions from sbt builds (not needed from IntelliJ 14, it supports sbt/scala projects through the Scala plugin).
+* [*Sbt-Native-Packager ★ 439 ⧗ 2*](https://github.com/sbt/sbt-native-packager) - Bundle up Scala software for native packaging systems, like deb, rpm, homebrew, msi..
+* [*Sbt-One-Jar ★ 180 ⧗ 20*](https://github.com/sbt/sbt-onejar) - Packages your project using One-JAR™.
+* [*sbt-pack ★ 170 ⧗ 1*](https://github.com/xerial/sbt-pack) - A sbt plugin for creating distributable Scala packages.
+* [*Sbt-Revolver ★ 358 ⧗ 1*](https://github.com/spray/sbt-revolver) - Fork & Stop processes from sbt.
+* [*Sbt-Start-Script ★ 133 ⧗ 11*](https://github.com/sbt/sbt-start-script) - Create a "start" script to run the program.
+* [*Sbt-Sublime ★ 113 ⧗ 0*](https://github.com/orrsella/sbt-sublime) - Create Sublime Text projects with library dependencies sources
+* [*Sbt-Updates ★ 197 ⧗ 0*](https://github.com/rtimush/sbt-updates) - Shows sbt project's dependency updates.
+* [*Sbt-Versions ★ 7 ⧗ 0*](https://github.com/sksamuel/sbt-versions) - Plugin that checks for updated versions of your project's dependencies.
+* [*ScalaKata ★ 124 ⧗ 9*](https://github.com/MasseGuillaume/ScalaKata) - Scala playground & Documentation tool.
+* [*tut ★ 109 ⧗ 4*](https://github.com/tpolecat/tut) - Tool for writing documentation with typechecked examples.
+* [*xsbt-web-plugin ★ 288 ⧗ 4*](https://github.com/earldouglas/xsbt-web-plugin) - Build enterprise J2EE Web applications in Scala.
+* [Zeppelin ★ ? ⧗ ?](http://zeppelin-project.org/) - Scala and Spark Notebook (like IPython Notebook)
 
 ## Other
 
 *something that does not fit in any category.*
 
-* [ScalaSTM](https://nbronson.github.io/scala-stm/) - Software Transaction Memory for Scala
+* [ScalaSTM ★ ? ⧗ ?](https://nbronson.github.io/scala-stm/) - Software Transaction Memory for Scala
 
 ## XML / HTML
 
 *Xml and Html generation and processing*
 
-* [Scalatags](https://github.com/lihaoyi/scalatags) - Write html as scala code and have your ide syntax check it.
+* [*Scalatags ★ 313 ⧗ 0*](https://github.com/lihaoyi/scalatags) - Write html as scala code and have your ide syntax check it.
 
 ## Learning Scala
 
 *Nice books, blogs and other resources to learn Scala*
 
-* [The Neophyte's Guide to Scala](http://danielwestheide.com/scala/neophytes.html)
-* [Scala in Depth](http://www.manning.com/suereth/)
+* [Scala in Depth ★ ? ⧗ ?](http://www.manning.com/suereth/) - None
+* [The Neophyte's Guide to Scala ★ ? ⧗ ?](http://danielwestheide.com/scala/neophytes.html) - None
 
 ## Tools
 
-* [Scalastyle](https://github.com/scalastyle/scalastyle) – Scala style checker.
-* [Codacy](https://www.codacy.com/) - Automated Code Reviews for Scala
-* [Wartremover](https://github.com/puffnfresh/wartremover) - Wartremover a flexible Scala code linting tool
-* [Abide](https://github.com/scala/scala-abide) - Library for quick scala code checking and validation
-* [Scoverage](https://github.com/scoverage) - Scala Code Coverage tool
-* [Gitbucket](https://github.com/takezoe/gitbucket) - The easily installable GitHub clone powered by Scala
-* [Scapegoat](https://github.com/sksamuel/scalac-scapegoat-plugin) - Scala compiler plugin for static code analysis
+* [*Abide ★ 169 ⧗ 1*](https://github.com/scala/scala-abide) - Library for quick scala code checking and validation
+* [Codacy ★ ? ⧗ ?](https://www.codacy.com/) - Automated Code Reviews for Scala
+* [*Gitbucket ★ 4381 ⧗ 0*](https://github.com/takezoe/gitbucket) - The easily installable GitHub clone powered by Scala
+* [*Scalastyle ★ 293 ⧗ 7*](https://github.com/scalastyle/scalastyle) - Scala style checker.
+* [*Scapegoat ★ 94 ⧗ 7*](https://github.com/sksamuel/scalac-scapegoat-plugin) - Scala compiler plugin for static code analysis
+* [Scoverage ★ ? ⧗ ?](https://github.com/scoverage) - Scala Code Coverage tool
+* [*Wartremover ★ 366 ⧗ 4*](https://github.com/puffnfresh/wartremover) - Wartremover a flexible Scala code linting tool
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Awesome Scala
+Awesome Scala [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 =============
 
 A community driven list of useful Scala libraries, frameworks and software. This is not a catalog of all the libraries, just a starting point for your explorations. Inspired by [awesome-python](https://github.com/vinta/awesome-python). Other amazingly awesome lists can be found in the [awesome-awesomeness](https://github.com/bayandin/awesome-awesomeness) list.
@@ -9,11 +9,13 @@ A community driven list of useful Scala libraries, frameworks and software. This
     - [Web Frameworks](#web-frameworks)
     - [i18n](#i18n)
     - [Authentication](#authentication)
+    - [Authorization](#authorization)
     - [Testing](#testing)
     - [JSON Manipulation](#json-manipulation)
     - [Serialization](#serialization)
     - [Science and Data Analysis](#science-and-data-analysis)
     - [Big Data](#big-data)
+    - [Image processing and image analysis](#image-processing-and-image-analysis)
     - [Functional Reactive Programming](#functional-reactive-programming)
     - [Modularization and Dependency Injection](#modularization-and-dependency-injection)
     - [Distributed Systems](#distributed-systems)
@@ -29,279 +31,323 @@ A community driven list of useful Scala libraries, frameworks and software. This
     - [Other](#other)
     - [Tools](#tools)
     - [Learning Scala](#learning-scala)
+    - [JavaScript](#javascript)
 - [Contributing](#contributing)
 
 ## Database
 
 *Database access libraries in Scala.*
 
-* [Activate ★ 249 ⧗ 4](https://github.com/fwbrasil/activate) - Pluggable object persistence in Scala.
-* [doobie ★ 263 ⧗ 1](https://github.com/tpolecat/doobie) - Pure functional JDBC layer for Scala.
-* [Elastic4s ★ 401 ⧗ 0](https://github.com/sksamuel/elastic4s) - A scala DSL / reactive client for Elasticsearch
-* [MapperDao ★ 2 ⧗ 76](https://github.com/kostaskougios/mapperdao) - An ORM library for oracle, mysql, mssql, and postgresql
-* [Phantom ★ 278 ⧗ 0](https://github.com/websudos/phantom) - Reactive type safe Scala driver for Apache Cassandra.
-* [**PostgreSQL and MySQL async ★ 647 ⧗ 0**](https://github.com/mauricio/postgresql-async) - Async database drivers to talk to PostgreSQL and MySQL in Scala.
-* [ReactiveCouchbase ★ ? ⧗ ?](http://reactivecouchbase.org/) - Reactive Scala Driver for Couchbase. Also includes a Play plug-in. An official plug-in is also in development.
-* [**ReactiveMongo ★ 573 ⧗ 3**](https://github.com/ReactiveMongo/ReactiveMongo) - Reactive Scala Driver for MongoDB.
-* [ReactiveNeo ★ 21 ⧗ 1](https://github.com/websudos/reactiveneo) - Reactive type-safe Scala driver for Neo4J.
-* [Salat ★ ? ⧗ ?](https://github.com/novus/salat/) - ORM for MongoDB. A related Play-plugin is also available.
-* [Scala ActiveRecord ★ 229 ⧗ 3](https://github.com/aselab/scala-activerecord) - ORM library for scala, inspired by ActiveRecord of Ruby on Rails.
-* [ScalikeJDBC ★ 474 ⧗ 1](https://github.com/scalikejdbc/scalikejdbc) - A tidy SQL-based DB access library for Scala developers.
-* [**Slick ★ 1261 ⧗ 0**](https://github.com/slick/slick) - Modern database query and access library for Scala.
-* [Sorm ★ 178 ⧗ 2](https://github.com/sorm/sorm) - A functional boilerplate-free Scala ORM.
-* [Squeryl ★ 439 ⧗ 2](https://github.com/squeryl/squeryl) - A Scala DSL for talking with databases with minimum verbosity and maximum type safety.
-* [Tepkin ★ 81 ⧗ 5](https://github.com/fehmicansaglam/tepkin) - Reactive MongoDB Driver for Scala built on top of Akka IO and Akka Streams.
+* [Memcontinuationed](https://github.com/Atry/memcontinuationed) - Memcached client for Scala.
+* [Activate](https://github.com/fwbrasil/activate) — Pluggable object persistence in Scala.
+* [Elastic4s](https://github.com/sksamuel/elastic4s) - A scala DSL / reactive client for Elasticsearch
+* [Phantom](https://github.com/websudos/phantom) — Reactive type safe Scala driver for Apache Cassandra.
+* [ReactiveNeo](https://github.com/websudos/reactiveneo) - Reactive type-safe Scala driver for Neo4J.
+* [PostgreSQL and MySQL async](https://github.com/mauricio/postgresql-async) — Async database drivers to talk to PostgreSQL and MySQL in Scala.
+* [ReactiveCouchbase](http://reactivecouchbase.org/) — Reactive Scala Driver for Couchbase. Also includes a Play plug-in. An official plug-in is also in development.
+* [ReactiveMongo](https://github.com/ReactiveMongo/ReactiveMongo) — Reactive Scala Driver for MongoDB.
+* [Salat](https://github.com/novus/salat/) — ORM for MongoDB. A related Play-plugin is also available.
+* [Scala ActiveRecord](https://github.com/aselab/scala-activerecord) — ORM library for scala, inspired by ActiveRecord of Ruby on Rails.
+* [ScalikeJDBC](https://github.com/scalikejdbc/scalikejdbc) — A tidy SQL-based DB access library for Scala developers.
+* [Slick](https://github.com/slick/slick) — Modern database query and access library for Scala.
+* [Sorm](https://github.com/sorm/sorm) — A functional boilerplate-free Scala ORM.
+* [Squeryl](https://github.com/squeryl/squeryl) — A Scala DSL for talking with databases with minimum verbosity and maximum type safety.
+* [doobie](https://github.com/tpolecat/doobie) - Pure functional JDBC layer for Scala.
+* [MapperDao](https://github.com/kostaskougios/mapperdao) - An ORM library for oracle, mysql, mssql, and postgresql
+* [Tepkin](https://github.com/fehmicansaglam/tepkin) — Reactive MongoDB Driver for Scala built on top of Akka IO and Akka Streams.
+* [Casbah](http://mongodb.github.io/casbah/) ([repo](https://github.com/mongodb/casbah)) - Officially supported Scala driver for MongoDB
+* [rediscala](https://github.com/etaty/rediscala) - Non-blocking, Reactive Redis driver for Scala (with Sentinel support)
 
 ## Graphical User Interfaces
 
 *Libraries for creation of graphical user interfaces*
 
-* [ScalaFX ★ ? ⧗ ?](http://www.scalafx.org/) - Scala DSL for creating Graphical User Interfaces that sits on top of JavaFX.
+* [ScalaFX](http://www.scalafx.org/) - Scala DSL for creating Graphical User Interfaces that sits on top of JavaFX.
 
 ## Web Frameworks
 
 *Scala frameworks for web development.*
 
-* [Chaos ★ 141 ⧗ 3](https://github.com/mesosphere/chaos) - A lightweight framework for writing REST services in Scala.
-* [Colossus ★ ? ⧗ ?](http://tumblr.github.io/colossus/) - lightweight framework for building high-performance applications in Scala that require non-blocking network I/O.
-* [**Finatra ★ 840 ⧗ 0**](https://github.com/twitter/finatra) - A sinatra-inspired web framework for scala, running on top of Finagle.
-* [**Lift ★ 905 ⧗ 2**](https://github.com/lift/framework) - Secure and powerful full stack web framework ([discussion](https://github.com/lauris/awesome-scala/pull/19)).
-* [**Play ★ 6561 ⧗ 0**](https://github.com/playframework/playframework) - Makes it easy to build scalable, fast and real-time web applications with Java & Scala.
-* [Reactive ★ 187 ⧗ 34](https://github.com/nafg/reactive) - FRP and web abstractions, which can be plugged into any web framework (currently only has bindings for Lift).
-* [**Scalatra ★ 1705 ⧗ 0**](https://github.com/scalatra/scalatra) - Tiny Scala high-performance, async web framework, inspired by Sinatra.
-* [Skinny Framework ★ 434 ⧗ 0](https://github.com/skinny-framework/skinny-framework) - A full-stack web app framework upon Scalatra for rapid Development in Scala.
-* [Socko ★ ? ⧗ ?](http://sockoweb.org/) - An embedded Scala web server powered by Netty networking and Akka processing.
-* [**Spray ★ 2003 ⧗ 0**](https://github.com/spray/spray) - A suite of scala libraries for building and consuming RESTful web services on top of Akka.
-* [**Unfiltered ★ 592 ⧗ 0**](https://github.com/unfiltered/unfiltered) - A modular set of unopinionated primitives for servicing HTTP and WebSocket requests in Scala.
-* [Xitrum ★ ? ⧗ ?](http://xitrum-framework.github.io/) - An async and clustered Scala web framework and HTTP(S) server fusion on top of Netty, Akka, and Hazelcast.
+* [Play](https://github.com/playframework/playframework) — Makes it easy to build scalable, fast and real-time web applications with Java & Scala.
+* [Lift](https://github.com/lift/framework) — Secure and powerful full stack web framework ([discussion](https://github.com/lauris/awesome-scala/pull/19)).
+* [Skinny Framework](https://github.com/skinny-framework/skinny-framework) — A full-stack web app framework upon Scalatra for rapid Development in Scala.
+* [Scalatra](https://github.com/scalatra/scalatra) — Tiny Scala high-performance, async web framework, inspired by Sinatra.
+* [Spray](https://github.com/spray/spray) — A suite of scala libraries for building and consuming RESTful web services on top of Akka.
+* [Finatra](https://github.com/twitter/finatra) — A sinatra-inspired web framework for scala, running on top of Finagle.
+* [Reactive](https://github.com/nafg/reactive) — FRP and web abstractions, which can be plugged into any web framework (currently only has bindings for Lift).
+* [Chaos](https://github.com/mesosphere/chaos) — A lightweight framework for writing REST services in Scala.
+* [Xitrum](http://xitrum-framework.github.io/) — An async and clustered Scala web framework and HTTP(S) server fusion on top of Netty, Akka, and Hazelcast.
+* [Unfiltered](https://github.com/unfiltered/unfiltered) — A modular set of unopinionated primitives for servicing HTTP and WebSocket requests in Scala.
+* [Colossus](http://tumblr.github.io/colossus/) — lightweight framework for building high-performance applications in Scala that require non-blocking network I/O.
+* [Socko](http://sockoweb.org/) — An embedded Scala web server powered by Netty networking and Akka processing.
 
 ## i18n
 
 *Scala libraries for i18n.*
 
-* [scala-xgettext ★ 13 ⧗ 53](https://github.com/xitrum-framework/scala-xgettext) - A compiler plugin that acts like GNU xgettext command to extract i18n strings in Scala source code files to Gettext .po file.
-* [Scaposer ★ 24 ⧗ 10](https://github.com/xitrum-framework/scaposer) - GNU Gettext .po file loader for Scala.
+* [Scaposer](https://github.com/xitrum-framework/scaposer) – GNU Gettext .po file loader for Scala.
+* [scala-xgettext](https://github.com/xitrum-framework/scala-xgettext) – A compiler plugin that acts like GNU xgettext command to extract i18n strings in Scala source code files to Gettext .po file.
 
 ## Authentication
 
 *Libraries for implementing authentications schemes.*
 
-* [play-pac4j ★ 6 ⧗ 11](https://github.com/leleuj/play-pac4j) - Profile & Authentication Client in Scala for CAS, OAuth, OpenID, SAML & HTTP protocols and Play 2.x framework.
-* [play-silhouette ★ 327 ⧗ 0](https://github.com/mohiva/play-silhouette) - Authentication library for Play Framework applications that supports several authentication methods, including OAuth1, OAuth2, OpenID, Credentials or custom authentication schemes.
-* [play2-auth ★ 478 ⧗ 2](https://github.com/t2v/play2-auth) - Play2.x Authentication and Authorization module.
-* [scala-oauth2-provider ★ 226 ⧗ 3](https://github.com/nulab/scala-oauth2-provider) - OAuth 2.0 server-side implementation written in Scala.
-* [**SecureSocial ★ 1105 ⧗ 2**](https://github.com/jaliss/securesocial) - A module that provides OAuth, OAuth2 and OpenID authentication for Play Framework applications.
+* [scala-oauth2-provider](https://github.com/nulab/scala-oauth2-provider) — OAuth 2.0 server-side implementation written in Scala.
+* [SecureSocial](https://github.com/jaliss/securesocial) — A module that provides OAuth, OAuth2 and OpenID authentication for Play Framework applications.
+* [play2-auth](https://github.com/t2v/play2-auth) — Play2.x Authentication and Authorization module.
+* [play-pac4j](https://github.com/leleuj/play-pac4j) — Profile & Authentication Client in Scala for CAS, OAuth, OpenID, SAML & HTTP protocols and Play 2.x framework.
+* [play-silhouette](https://github.com/mohiva/play-silhouette) — Authentication library for Play Framework applications that supports several authentication methods, including OAuth1, OAuth2, OpenID, Credentials or custom authentication schemes.
+
+## Authorization
+
+*Libraries for implementing authorization strategies.*
+
+* [deadbolt-2](https://github.com/schaloner/deadbolt-2) — A Play 2.x module supporting role-based and proprietary authorization; idiomatic APIs for Scala and Java APIs are provided.
+
 
 ## Testing
 
 *Libraries for code testing.*
 
-* [Gatling ★ ? ⧗ ?](http://gatling-tool.org/) - Async Scala-Akka-Netty based Stress Tool.
-* [**ScalaCheck ★ 832 ⧗ 1**](https://github.com/rickynils/scalacheck) - Property-based testing for Scala.
-* [ScalaMeter ★ ? ⧗ ?](https://scalameter.github.io/) - Performance &  memory footprint measuring, regression testing.
-* [ScalaMock ★ ? ⧗ ?](http://scalamock.org) - Scala native mocking framework
-* [ScalaTest ★ 269 ⧗ 2](https://github.com/scalatest/scalatest) - A testing tool for Scala and Java developers.
-* [Scalive ★ 114 ⧗ 29](https://github.com/xitrum-framework/scalive) - Connect a Scala REPL to running JVM processes without any prior setup; this library is used for inspecting systems in production mode.
-* [Specs2 ★ 443 ⧗ 0](https://github.com/etorreborre/specs2) - Software Specifications for Scala.
-* [µTest ★ 117 ⧗ 4](https://github.com/lihaoyi/utest) - A tiny, portable testing library for Scala.
+* [ScalaCheck](https://github.com/rickynils/scalacheck) — Property-based testing for Scala.
+* [ScalaTest](https://github.com/scalatest/scalatest) — A testing tool for Scala and Java developers.
+* [ScalaMeter](https://scalameter.github.io/) - Performance &  memory footprint measuring, regression testing.
+* [Specs2](https://github.com/etorreborre/specs2) — Software Specifications for Scala.
+* [µTest](https://github.com/lihaoyi/utest) — A tiny, portable testing library for Scala.
+* [Scalive](https://github.com/xitrum-framework/scalive) — Connect a Scala REPL to running JVM processes without any prior setup; this library is used for inspecting systems in production mode.
+* [Gatling](http://gatling-tool.org/) – Async Scala-Akka-Netty based Stress Tool.
+* [ScalaMock](http://scalamock.org) – Scala native mocking framework
 
 ## JSON Manipulation
 
 *Libraries for work with json.*
 
-* [argonaut ★ ? ⧗ ?](http://argonaut.io/) - Purely Functional JSON in Scala.
-* [jackson-module-scala ★ 224 ⧗ 8](https://github.com/FasterXML/jackson-module-scala) - Add-on module for Jackson to support Scala-specific datatypes.
-* [json4s ★ 467 ⧗ 1](https://github.com/json4s/json4s) - Project aims to provide a single AST to be used by other scala json libraries.
-* [play-json ★ ? ⧗ ?](https://github.com/playframework/playframework/tree/master/framework/src/play-json) - Flexible and powerful JSON manipulation, validation and serialization, with no reflection at runtime.
-* [scalajack ★ 62 ⧗ 4](https://github.com/gzoller/ScalaJack) - Fast 'n easy JSON serialization with optional MongoDB support.  Uses Jackson under the hood.
-* [spray-json ★ 403 ⧗ 2](https://github.com/spray/spray-json) - Lightweight, clean and efficient JSON implementation in Scala.
+* [json4s](https://github.com/json4s/json4s) — Project aims to provide a single AST to be used by other scala json libraries.
+* [spray-json](https://github.com/spray/spray-json) — Lightweight, clean and efficient JSON implementation in Scala.
+* [argonaut](http://argonaut.io/) — Purely Functional JSON in Scala.
+* [jackson-module-scala](https://github.com/FasterXML/jackson-module-scala) — Add-on module for Jackson to support Scala-specific datatypes.
+* [play-json](https://github.com/playframework/playframework/tree/master/framework/src/play-json) — Flexible and powerful JSON manipulation, validation and serialization, with no reflection at runtime.
+* [scalajack](https://github.com/gzoller/ScalaJack) - Fast 'n easy JSON serialization with optional MongoDB support.  Uses Jackson under the hood.
+* [circe](https://github.com/travisbrown/circe) - JSON library based on Argonaut, depends on Cats
 
 ## Serialization
 
 *Libraries for serializing and deserializing data for storage or transport.*
 
-* [Chill ★ 285 ⧗ 6](https://github.com/twitter/chill) - Extensions for the Kryo serialization library to ease configuration in systems like Hadoop and Storm.
-* [**Pickling ★ 632 ⧗ 1**](https://github.com/scala/pickling) - Fast, customizable, boilerplate-free pickling support.
-* [ScalaPB ★ ? ⧗ ?](http://trueaccord.github.io/ScalaPB/) - A Protocol Buffer generator for Scala.
-* [scodec ★ 301 ⧗ 4](https://github.com/scodec/scodec) - A combinator library for working with binary data.
-* [Scrooge ★ ? ⧗ ?](http://twitter.github.io/scrooge/) - An Apache Thrift code generator for Scala.
-* [validation ★ 101 ⧗ 7](https://github.com/jto/validation) - Advanced validation & serialization for JSON, HTML form data, etc, with no reflection at runtime.
-* [µPickle ★ ? ⧗ ?](http://lihaoyi.github.io/upickle-pprint/upickle/) - A lightweight serialization library for Scala that works in ScalaJS, allowing transfer of structured data between the JVM and JavaScript.
+* [Pickling](https://github.com/scala/pickling) — Fast, customizable, boilerplate-free pickling support.
+* [scodec](https://github.com/scodec/scodec) — A combinator library for working with binary data.
+* [Scrooge](http://twitter.github.io/scrooge/) — An Apache Thrift code generator for Scala.
+* [validation](https://github.com/jto/validation) — Advanced validation & serialization for JSON, HTML form data, etc, with no reflection at runtime.
+* [Chill](https://github.com/twitter/chill) — Extensions for the Kryo serialization library to ease configuration in systems like Hadoop and Storm.
+* [µPickle](http://lihaoyi.github.io/upickle-pprint/upickle/) — A lightweight serialization library for Scala that works in ScalaJS, allowing transfer of structured data between the JVM and JavaScript.
+* [ScalaPB](http://trueaccord.github.io/ScalaPB/) - A Protocol Buffer generator for Scala.
+* [ScalaBuff](https://github.com/SandroGrzicic/ScalaBuff) - a Scala Protocol Buffers (protobuf) compiler
 
 ## Science and Data Analysis
 
 *Libraries for scientific computing, data analysis and numerical processing.*
 
-* [**Algebird ★ 955 ⧗ 0**](https://github.com/twitter/algebird) - Abstract Algebra for Scala.
-* [Axle ★ ? ⧗ ?](http://axle-lang.org) - Spire-based DSL for scientific cloud computing.
-* [**Breeze ★ 1087 ⧗ 0**](https://github.com/scalanlp/breeze) - Breeze is a numerical processing library for Scala.
-* [Chalk ★ 165 ⧗ 0](https://github.com/scalanlp/chalk) - Chalk is a natural language processing library.
-* [FACTORIE ★ 322 ⧗ 4](https://github.com/factorie/factorie) - A toolkit for deployable probabilistic modeling, implemented as a software library in Scala.
-* [Figaro ★ 201 ⧗ 8](https://github.com/p2t2/figaro) - Figaro is a probabilistic programming language that supports development of very rich probabilistic models.
-* [MGO ★ 9 ⧗ 96](https://github.com/romainreuillon/mgo) - Modular multi-objective evolutionary algorithm optimization library enforcing immutability.
-* [MLLib ★ ? ⧗ ?](https://spark.apache.org/mllib/) - Machine Learning framework for Spark
-* [OpenMOLE ★ 9 ⧗ 28](https://github.com/ISCPIF/openmole) - OpenMOLE (Open MOdeL Experiment) is a workflow engine designed to leverage the computing power of distributed execution environments for naturally parallel processes.
-* [**PredictionIO ★ 7422 ⧗ 0**](https://github.com/PredictionIO/PredictionIO) - machine learning server for developers and data scientists. Built on Apache Spark, HBase and Spray
-* [Saddle ★ 324 ⧗ 8](https://github.com/saddle/saddle) - A minimalist port of Pandas to Scala
-* [**Spire ★ 737 ⧗ 4**](https://github.com/non/spire) - Powerful new number types and numeric abstractions for Scala.
-* [Squants ★ 206 ⧗ 0](https://github.com/garyKeorkunian/squants) - The Scala API for Quantities, Units of Measure and Dimensional Analysis.
+* [Algebird](https://github.com/twitter/algebird) — Abstract Algebra for Scala.
+* [Axle](http://axle-lang.org) — Spire-based DSL for scientific cloud computing.
+* [Breeze](https://github.com/scalanlp/breeze) — Breeze is a numerical processing library for Scala.
+* [Chalk](https://github.com/scalanlp/chalk) — Chalk is a natural language processing library.
+* [FACTORIE](https://github.com/factorie/factorie) — A toolkit for deployable probabilistic modeling, implemented as a software library in Scala.
+* [Figaro](https://github.com/p2t2/figaro) - Figaro is a probabilistic programming language that supports development of very rich probabilistic models.
+* [MGO](https://github.com/romainreuillon/mgo) — Modular multi-objective evolutionary algorithm optimization library enforcing immutability.
+* [MLLib](https://spark.apache.org/mllib/) — Machine Learning framework for Spark
+* [OpenMOLE](https://github.com/ISCPIF/openmole) — OpenMOLE (Open MOdeL Experiment) is a workflow engine designed to leverage the computing power of distributed execution environments for naturally parallel processes.
+* [Saddle](https://github.com/saddle/saddle) — A minimalist port of Pandas to Scala
+* [Spire](https://github.com/non/spire) — Powerful new number types and numeric abstractions for Scala.
+* [Squants](https://github.com/garyKeorkunian/squants) — The Scala API for Quantities, Units of Measure and Dimensional Analysis.
+* [PredictionIO](https://github.com/PredictionIO/PredictionIO) - machine learning server for developers and data scientists. Built on Apache Spark, HBase and Spray
+* [OscaR](https://bitbucket.org/oscarlib/oscar/wiki/Home) - a Scala toolkit for solving Operations Research problems
 
 ## Big Data
 
+* [Spark](http://spark.apache.org/) — Lightning fast cluster computing — up to 100x faster than Hadoop for iterative algorithms (memory caching) and up to 10x faster than Hadoop for single-pass MapReduce jobs. Compatible with YARN-enabled Hadoop clusters, can run on Mesos and in stand-alone mode as well.
+* [Sparkta](http://github.com/Stratio/sparkta) — Real Time Aggregation based on Spark Streaming.
+* [Scalding](https://github.com/twitter/scalding) — A Scala binding for the Cascading abstraction of Hadoop MapReduce.
+* [Summingbird](https://github.com/twitter/summingbird) — An implementation of the “lambda architecture” as a software abstraction — a single API for Hadoop and Storm.
+* [Shadoop](https://github.com/adamretter/shadoop) - A Scala DSL for Hadoop MapReduce.
+* [Scrunch](http://crunch.apache.org/scrunch.html) — A Scala wrapper for [Apache Crunch](http://crunch.apache.org/index.html) which provides a framework for writing, testing, and running MapReduce pipelines.
+* [GridScale](https://github.com/romainreuillon/gridscale) — A Scala API for computing clusters and grids.
+* [BIDMach](https://github.com/BIDData/BIDMach) - CPU and GPU machine learning library, using JNI for GPU computation.
 * [Scoobi] (https://github.com/nicta/scoobi) - Write type-safe Hadoop programs in idiomatic Scala way
+* [Gearpump](https://github.com/intel-hadoop/gearpump) - Lightweight real-time big data streaming engine
+* [Scoozie](https://github.com/klout/scoozie) - Scala DSL on top of Oozie XML
 
-* [BIDMach ★ 395 ⧗ 0](https://github.com/BIDData/BIDMach) - CPU and GPU machine learning library, using JNI for GPU computation.
-* [Gearpump ★ 314 ⧗ 1](https://github.com/intel-hadoop/gearpump) - Lightweight real-time big data streaming engine
-* [GridScale ★ 7 ⧗ 4](https://github.com/romainreuillon/gridscale) - A Scala API for computing clusters and grids.
-* [**Scalding ★ 2184 ⧗ 1**](https://github.com/twitter/scalding) - A Scala binding for the Cascading abstraction of Hadoop MapReduce.
-* [scoozie ★ 47 ⧗ 4](https://github.com/klout/scoozie) - Scala DSL on top of Oozie XML.
-* [Scrunch ★ ? ⧗ ?](http://crunch.apache.org/scrunch.html) - A Scala wrapper for [Apache Crunch](http://crunch.apache.org/index.html) which provides a framework for writing, testing, and running MapReduce pipelines.
-* [Shadoop ★ 7 ⧗ 134](https://github.com/adamretter/shadoop) - A Scala DSL for Hadoop MapReduce.
-* [Spark ★ ? ⧗ ?](http://spark.apache.org/) - Lightning fast cluster computing — up to 100x faster than Hadoop for iterative algorithms (memory caching) and up to 10x faster than Hadoop for single-pass MapReduce jobs. Compatible with YARN-enabled Hadoop clusters, can run on Mesos and in stand-alone mode as well.
-* [**Summingbird ★ 1522 ⧗ 1**](https://github.com/twitter/summingbird) - An implementation of the “lambda architecture” as a software abstraction — a single API for Hadoop and Storm.
+## Image processing and image analysis
+
+*2D and 3D image processing and image analysis*
+
+* [scalismo](https://github.com/unibas-gravis/scalismo) - Shape modelling and  model-based image analysis.
 
 ## Functional Reactive Programming
 
 *Event streams, signals, observables, etc.*
 
-* [Monifu ★ 147 ⧗ 4](https://github.com/monifu/monifu) - Extensions to Scala’s standard library for multi-threading primitives and functional reactive programming. Scala.js compatible.
-* [Reactive Collections ★ 71 ⧗ 34](https://github.com/storm-enroute/reactive-collections) - A library that incorporates event streams and signals with specialized collections called reactive containers, and expresses concurrency using isolates and channels.
-* [RxScala ★ 280 ⧗ 1](https://github.com/ReactiveX/RxScala) - Reactive Extensions for Scala – a library for composing asynchronous and event-based programs using observable sequences
-* [scala.frp ★ 17 ⧗ 112](https://github.com/dylemma/scala.frp) - Functional Reactive Programming for Scala (event streams).
-* [**Scala.Rx ★ 518 ⧗ 3**](https://github.com/lihaoyi/scala.rx) - An experimental library for Functional Reactive Programming in Scala (reactive variables). Scala.js compatible.
-* [Vertx.io ★ ? ⧗ ?](http://vertx.io/) - A polyglot reactive application platform for the JVM which aims to be an alternative to node.js. Its concurrency model resembles actors. It supports [Scala](http://vertx.io/core_manual_scala.html), Clojure, Java, Javascript, Ruby, Groovy and Python.
+* [Scala.Rx](https://github.com/lihaoyi/scala.rx) — An experimental library for Functional Reactive Programming in Scala (reactive variables). Scala.js compatible.
+* [scala.frp](https://github.com/dylemma/scala.frp) — Functional Reactive Programming for Scala (event streams).
+* [RxScala](https://github.com/ReactiveX/RxScala) — Reactive Extensions for Scala – a library for composing asynchronous and event-based programs using observable sequences
+* [Reactive Collections](https://github.com/storm-enroute/reactive-collections) – A library that incorporates event streams and signals with specialized collections called reactive containers, and expresses concurrency using isolates and channels.
+* [Vertx.io](http://vertx.io/) – A polyglot reactive application platform for the JVM which aims to be an alternative to node.js. Its concurrency model resembles actors. It supports [Scala](http://vertx.io/core_manual_scala.html), Clojure, Java, Javascript, Ruby, Groovy and Python.
+* [Monifu](https://github.com/monifu/monifu) — Extensions to Scala’s standard library for multi-threading primitives and functional reactive programming. Scala.js compatible.
+* [SynapseGrid](https://github.com/Primetalk/SynapseGrid) — an FRP framework for constructing reactive real-time immutable data flow systems. It implements an original way of running and organizing event-driven systems based on Petri nets. The topology can be viewed as a .dot graph. The library is compatible with Akka and can seamlessly communicate with other actors.
 
 ## Modularization and Dependency Injection
 
 *Modularization of applications, dependency injection, etc.*
 
-* [Domino ★ 27 ⧗ 0](https://github.com/helgoboss/domino) - Write elegant OSGi bundle activators in Scala.
-* [MacWire ★ 342 ⧗ 2](https://github.com/adamw/macwire) - Scala Macro to generate wiring code for class instantiation. DI container replacement.
-* [Scaldi ★ 171 ⧗ 2](https://github.com/scaldi/scaldi) - Lightweight Scala Dependency Injection Library.
-* [Sclasner ★ 7 ⧗ 163](https://github.com/xitrum-framework/sclasner) - Scala classpath scanner.
-* [SubCut ★ 377 ⧗ 15](https://github.com/dickwall/subcut) - Scala Uniquely Bound Classes Under Traits.
+* [Domino](https://github.com/helgoboss/domino) — Write elegant OSGi bundle activators in Scala.
+* [Sclasner](https://github.com/xitrum-framework/sclasner) - Scala classpath scanner.
+* [Scaldi](https://github.com/scaldi/scaldi) — Lightweight Scala Dependency Injection Library.
+* [MacWire](https://github.com/adamw/macwire) — Scala Macro to generate wiring code for class instantiation. DI container replacement.
+* [SubCut](https://github.com/dickwall/subcut) — Scala Uniquely Bound Classes Under Traits.
+* [Scala-Guice](https://github.com/codingwell/scala-guice) — Scala extensions for Google Guice
 
 ## Distributed Systems
 
 *Libraries and frameworks for writing distributed applications.*
 
-* [Akka ★ ? ⧗ ?](http://akka.io/) - A toolkit and runtime for building highly concurrent, distributed, and fault tolerant event-driven applications.
-* [Finagle ★ ? ⧗ ?](https://twitter.github.io/finagle/) - An extensible, protocol-agnostic RPC system designed for high performance and concurrency.
-* [Glokka ★ 35 ⧗ 9](https://github.com/xitrum-framework/glokka) - Library to register and lookup actors by names in an Akka cluster.
+* [Akka](http://akka.io/) — A toolkit and runtime for building highly concurrent, distributed, and fault tolerant event-driven applications.
+* [Finagle](https://twitter.github.io/finagle/) — An extensible, protocol-agnostic RPC system designed for high performance and concurrency.
+* [Glokka](https://github.com/xitrum-framework/glokka) - Library to register and lookup actors by names in an Akka cluster.
+* [CurioDB](https://github.com/stephenmcd/curiodb) - Distributed & Persistent Redis Clone built with Scala & Akka.
 
 ## Extensions
 
 *Scala extensions.*
 
-* [**Cassovary ★ 737 ⧗ 0**](https://github.com/twitter/cassovary) - A Scala library that is designed from the ground up for space efficiency, handling graphs with billions of nodes and edges.
-* [Lamma ★ 42 ⧗ 4](https://github.com/maxcellent/lamma) - A Scala date library for date and schedule generation.
-* [Log4s ★ ? ⧗ ?](http://log4s.org) - Fast, Scala-friendly logging bindings on top of [SLF4J](http://slf4j.org/). Uses macros for extreme performance.
-* [Resolvable ★ 24 ⧗ 15](https://github.com/resolvable/resolvable) - A library to optimize fetching immutable data structures from several endpoints in several formats.
-* [**Scala Async ★ 514 ⧗ 0**](https://github.com/scala/async) - An asynchronous programming facility for Scala.
-* [Scala Blitz ★ ? ⧗ ?](http://scala-blitz.github.io/) - A library to speed up Scala collection operations by removing runtime overheads during compilation, and a custom data-parallel operation runtime.
-* [Scala Graph ★ ? ⧗ ?](http://www.scala-graph.org/) - A Scala library with basic graph functionality that seamlessly fits into the Scala standard collections library.
-* [Scalactic ★ ? ⧗ ?](http://www.scalactic.org/) - Small library of utilities related to quality that helps keeping code clear and correct.
-* [**Scalaz ★ 1979 ⧗ 0**](https://github.com/scalaz/scalaz) - An extension to the core Scala library for functional programming.
-* [**Shapeless ★ 1164 ⧗ 0**](https://github.com/milessabin/shapeless) - A type class and dependent type based generic programming library for Scala.
-* [**Twitter Util ★ 1224 ⧗ 0**](https://github.com/twitter/util) - General-purpose Scala libraries, including a future implementation and other concurrency tools.
+* [Stateless Future](https://github.com/qifun/stateless-future) - Asynchronous programming in fully featured Scala syntax.
+* [Scalaz](https://github.com/scalaz/scalaz) — An extension to the core Scala library for functional programming.
+* [Each](https://github.com/ThoughtWorksInc/each) — A macro library that converts native imperative syntax to [Scalaz](https://github.com/scalaz/scalaz)'s monadic expressions.
+* [Shapeless](https://github.com/milessabin/shapeless) — A type class and dependent type based generic programming library for Scala.
+* [Twitter Util](https://github.com/twitter/util) — General-purpose Scala libraries, including a future implementation and other concurrency tools.
+* [Scala Async](https://github.com/scala/async) — An asynchronous programming facility for Scala.
+* [Resolvable](https://github.com/resolvable/resolvable) — A library to optimize fetching immutable data structures from several endpoints in several formats.
+* [Scala Blitz](http://scala-blitz.github.io/) – A library to speed up Scala collection operations by removing runtime overheads during compilation, and a custom data-parallel operation runtime.
+* [Log4s](http://log4s.org) - Fast, Scala-friendly logging bindings on top of [SLF4J](http://slf4j.org/). Uses macros for extreme performance.
+* [Lamma](https://github.com/maxcellent/lamma) – A Scala date library for date and schedule generation.
+* [Scala Graph](http://www.scala-graph.org/) – A Scala library with basic graph functionality that seamlessly fits into the Scala standard collections library.
+* [Cassovary](https://github.com/twitter/cassovary) – A Scala library that is designed from the ground up for space efficiency, handling graphs with billions of nodes and edges.
+* [Scalactic](http://www.scalactic.org/) - Small library of utilities related to quality that helps keeping code clear and correct.
+* [Monocle](https://github.com/julien-truffaut/Monocle) - An Optics/Lens library for purely functional manipulation of immutable objects.
+* [Rapture](http://rapture.io/) ([repo](https://github.com/propensive/rapture)) - a collection of libraries for common, everyday programming tasks (I/O, JSON, i18n, etc.)
+* [refined](https://github.com/fthomas/refined) - Simple refinement types with compile- and runtime checking
 
 ## Misc
 
-* [REPLesent ★ 148 ⧗ 0](https://github.com/marconilanna/REPLesent) - A presentation tool built inside the Scala REPL. Runs code straight from your slides with a single keystroke.
+*Projects that don't fit into any specific category.*
+
+* [REPLesent](https://github.com/marconilanna/REPLesent) – A presentation tool built inside the Scala REPL. Runs code straight from your slides with a single keystroke.
+* [ScalaSTM](https://nbronson.github.io/scala-stm/) - Software Transaction Memory for Scala
+* [scala-ssh](https://github.com/sirthias/scala-ssh) - Remote shell access via SSH for your Scala applications
+* [Scalan](https://github.com/scalan/scalan) - A framework for development of domain-specific compilers in Scala 
 
 ## Android
 
 *Scala libraries and wrappers for Android development.*
 
-* [Android SDK Plugin for SBT ★ 347 ⧗ 0](https://github.com/pfn/android-sdk-plugin) - An sbt plugin that adds tasks for developing Android applications.
-* [Gradle Android Scala Plugin ★ 205 ⧗ 1](https://github.com/saturday06/gradle-android-scala-plugin) - A gradle plugin that allows you to use Scala with Android
-* [Macroid ★ 279 ⧗ 0](https://github.com/macroid/macroid) - A modular functional UI language for Android.
-* [**Scaloid ★ 1671 ⧗ 0**](https://github.com/pocorall/scaloid) - Less painful Android development with Scala.
+* [Scaloid](https://github.com/pocorall/scaloid) — Less painful Android development with Scala.
+* [Macroid](https://github.com/macroid/macroid) — A modular functional UI language for Android.
+* [Android SDK Plugin for SBT](https://github.com/pfn/android-sdk-plugin) — An sbt plugin that adds tasks for developing Android applications.
+* [Gradle Android Scala Plugin](https://github.com/saturday06/gradle-android-scala-plugin) - A gradle plugin that allows you to use Scala with Android
 
 ## HTTP
 
 *Scala libraries and wrappers for HTTP clients.*
 
-* [Dispatch ★ 293 ⧗ 1](https://github.com/dispatch/reboot) - Library for asynchronous HTTP interaction. It provides a Scala vocabulary for Java’s [async-http-client](https://github.com/AsyncHttpClient/async-http-client).
-* [Finch.io ★ 364 ⧗ 1](https://github.com/finagle/finch) - Purely Functional REST API atop of [Finagle](https://github.com/twitter/finagle).
-* [Netcaty ★ 9 ⧗ 30](https://github.com/ngocdaothanh/netcaty) - Simple net test client/server for Netty and Scala lovers.
-* [Newman ★ 205 ⧗ 24](https://github.com/stackmob/newman) - A REST DSL that tries to take the best from Dispatch, Finagle and Apache HttpClient. See [here](https://www.paypal-engineering.com/2014/02/13/hello-newman-a-rest-client-for-scala/) for rationale.
-* [scalaj-http ★ 274 ⧗ 1](https://github.com/scalaj/scalaj-http) - Simple scala wrapper for HttpURLConnection (including OAuth support).
-* [Scalaxb ★ 171 ⧗ 5](https://github.com/eed3si9n/scalaxb) - An XML data-binding tool for Scala that supports W3C XML Schema (xsd) and Web Services Description Language (wsdl) as the input file.
-* [Spray ★ ? ⧗ ?](http://spray.io/) - Actor-based library for http interaction.
-* [Tubesocks ★ 7 ⧗ 374](https://github.com/softprops/tubesocks) - Library supporting bi-directional communication with websocket servers.
+* [Dispatch](https://github.com/dispatch/reboot) — Library for asynchronous HTTP interaction. It provides a Scala vocabulary for Java’s [async-http-client](https://github.com/AsyncHttpClient/async-http-client).
+* [Netcaty](https://github.com/ngocdaothanh/netcaty) - Simple net test client/server for Netty and Scala lovers.
+* [Scalaxb](https://github.com/eed3si9n/scalaxb) — An XML data-binding tool for Scala that supports W3C XML Schema (xsd) and Web Services Description Language (wsdl) as the input file.
+* [Spray](http://spray.io/) — Actor-based library for http interaction.
+* [Tubesocks](https://github.com/softprops/tubesocks) — Library supporting bi-directional communication with websocket servers.
+* [scalaj-http](https://github.com/scalaj/scalaj-http) – Simple scala wrapper for HttpURLConnection (including OAuth support).
+* [Finch.io](https://github.com/finagle/finch) — Purely Functional REST API atop of [Finagle](https://github.com/twitter/finagle).
+* [Newman](https://github.com/stackmob/newman) — A REST DSL that tries to take the best from Dispatch, Finagle and Apache HttpClient. See [here](https://www.paypal-engineering.com/2014/02/13/hello-newman-a-rest-client-for-scala/) for rationale.
+
 
 ## Semantic Web
 
 *Scala libraries for interactions with the Web of Data, and other RDF tools.*
 
-* [Banana-RDF ★ 153 ⧗ 1](https://github.com/w3c/banana-rdf) - Scala-friendly abstractions for RDF and Linked Data technologies. Supports Jena, Sesame and native Scala.
+* [Banana-RDF](https://github.com/w3c/banana-rdf) – Scala-friendly abstractions for RDF and Linked Data technologies. Supports Jena, Sesame and native Scala.
 
 ## Metrics and Monitoring
 
 *Scala libraries for gathering metrics and monitoring applications.*
 
-* [Kamon ★ ? ⧗ ?](http://kamon.io) - Gathering metrics from applications built with Akka, Spray and Play! with support for user metrics as well.
+* [Kamon](http://kamon.io) - Gathering metrics from applications built with Akka, Spray and Play! with support for user metrics as well.
 
 ## Parsing
 
 *Scala libraries for creating parsers.*
 
-* [atto ★ 57 ⧗ 6](https://github.com/tpolecat/atto) - Pure functional incremental text parsing library for Scala, based on Attoparsec.
-* [Parboiled2 ★ 343 ⧗ 0](https://github.com/sirthias/parboiled2) - A Fast Parser Generator for Scala 2.10.3+.
-* [Scala Parser Combinators ★ 78 ⧗ 0](https://github.com/scala/scala-parser-combinators) - Scala Standard Parser Combinator Library.
+* [Scala Parser Combinators](https://github.com/scala/scala-parser-combinators) – Scala Standard Parser Combinator Library.
+* [Parboiled2](https://github.com/sirthias/parboiled2) – A Fast Parser Generator for Scala 2.10.3+.
+* [atto](https://github.com/tpolecat/atto) - Pure functional incremental text parsing library for Scala, based on Attoparsec.
 
 ## Sbt plugins
 
 *Sbt plugins to make your life easier.*
 
-* [Ammonite ★ ? ⧗ ?](http://lihaoyi.github.io/Ammonite/) - Ammonite is a collection of Scala libraries intended to improve the experience of using Scala as an system shell.
-* [Sbt-BuildInfo ★ 151 ⧗ 2](https://github.com/sbt/sbt-buildinfo) - Generates Scala source from build definition.
-* [Sbt-Dependency-Graph ★ 359 ⧗ 0](https://github.com/jrudolph/sbt-dependency-graph) - Create a dependency graph for your project.
-* [Sbt-Eclipse ★ 487 ⧗ 3](https://github.com/typesafehub/sbteclipse) - Create Eclipse project definitions from sbt builds.
-* [sbt-ide-settings ★ 15 ⧗ 1](https://github.com/Jetbrains/sbt-ide-settings) - SBT plugin for tweaking various IDE settings
-* [**Sbt-Idea ★ 940 ⧗ 0**](https://github.com/mpeltonen/sbt-idea) - Create IntelliJ IDEA project definitions from sbt builds (not needed from IntelliJ 14, it supports sbt/scala projects through the Scala plugin).
-* [Sbt-Native-Packager ★ 439 ⧗ 2](https://github.com/sbt/sbt-native-packager) - Bundle up Scala software for native packaging systems, like deb, rpm, homebrew, msi..
-* [Sbt-One-Jar ★ 180 ⧗ 20](https://github.com/sbt/sbt-onejar) - Packages your project using One-JAR™.
-* [sbt-pack ★ 170 ⧗ 1](https://github.com/xerial/sbt-pack) - A sbt plugin for creating distributable Scala packages.
-* [Sbt-Revolver ★ 358 ⧗ 1](https://github.com/spray/sbt-revolver) - Fork & Stop processes from sbt.
-* [Sbt-Start-Script ★ 133 ⧗ 11](https://github.com/sbt/sbt-start-script) - Create a "start" script to run the program.
-* [Sbt-Sublime ★ 113 ⧗ 0](https://github.com/orrsella/sbt-sublime) - Create Sublime Text projects with library dependencies sources
-* [Sbt-Updates ★ 197 ⧗ 0](https://github.com/rtimush/sbt-updates) - Shows sbt project's dependency updates.
-* [Sbt-Versions ★ 7 ⧗ 0](https://github.com/sksamuel/sbt-versions) - Plugin that checks for updated versions of your project's dependencies.
-* [ScalaKata ★ 124 ⧗ 9](https://github.com/MasseGuillaume/ScalaKata) - Scala playground & Documentation tool.
-* [tut ★ 109 ⧗ 4](https://github.com/tpolecat/tut) - Tool for writing documentation with typechecked examples.
-* [xsbt-web-plugin ★ 288 ⧗ 4](https://github.com/earldouglas/xsbt-web-plugin) - Build enterprise J2EE Web applications in Scala.
-* [Zeppelin ★ ? ⧗ ?](http://zeppelin-project.org/) - Scala and Spark Notebook (like IPython Notebook)
-
-## Other
-
-*something that does not fit in any category.*
-
-* [ScalaSTM ★ ? ⧗ ?](https://nbronson.github.io/scala-stm/) - Software Transaction Memory for Scala
+* [sbt-cppp](https://github.com/Atry/sbt-cppp) – A sbt plugin to support [Protocol Buffers](https://github.com/google/protobuf), especially in multi-project builds.
+* [sbt-haxe](https://github.com/qifun/sbt-haxe) – A Sbt plugin to compile Haxe sources.
+* [sbt-api-mappings](https://github.com/ThoughtWorksInc/sbt-api-mappings) - A Sbt plugin that resolves external API links to common Scala libraries.
+* [Pttrt](https://github.com/Atry/pttrt) - A sbt plugin, designed to pass data from compile-time to run-time.
+* [Sbt-Revolver](https://github.com/spray/sbt-revolver) – Fork & Stop processes from sbt.
+* [Sbt-Eclipse](https://github.com/typesafehub/sbteclipse) – Create Eclipse project definitions from sbt builds.
+* [Sbt-Idea](https://github.com/mpeltonen/sbt-idea) – Create IntelliJ IDEA project definitions from sbt builds (not needed from IntelliJ 14, it supports sbt/scala projects through the Scala plugin).
+* [Sbt-Native-Packager](https://github.com/sbt/sbt-native-packager) – Bundle up Scala software for native packaging systems, like deb, rpm, homebrew, msi..
+* [Sbt-Dependency-Graph](https://github.com/jrudolph/sbt-dependency-graph) – Create a dependency graph for your project.
+* [Sbt-Versions](https://github.com/sksamuel/sbt-versions) - Plugin that checks for updated versions of your project's dependencies.
+* [Sbt-One-Jar](https://github.com/sbt/sbt-onejar) – Packages your project using One-JAR™.
+* [Sbt-Start-Script](https://github.com/sbt/sbt-start-script) – Create a "start" script to run the program.
+* [Sbt-Sublime](https://github.com/orrsella/sbt-sublime) – Create Sublime Text projects with library dependencies sources
+* [ScalaKata2](https://github.com/MasseGuillaume/ScalaKata2) – Scala playground & Documentation tool.
+* [Zeppelin](http://zeppelin-project.org/) - Scala and Spark Notebook (like IPython Notebook)
+* [xsbt-web-plugin](https://github.com/earldouglas/xsbt-web-plugin) – Build enterprise J2EE Web applications in Scala.
+* [tut](https://github.com/tpolecat/tut) - Tool for writing documentation with typechecked examples.
+* [sbt-ide-settings](https://github.com/Jetbrains/sbt-ide-settings) - SBT plugin for tweaking various IDE settings
+* [Sbt-BuildInfo](https://github.com/sbt/sbt-buildinfo) – Generates Scala source from build definition.
+* [Sbt-Updates](https://github.com/rtimush/sbt-updates) – Shows sbt project's dependency updates.
+* [sbt-pack](https://github.com/xerial/sbt-pack) - A sbt plugin for creating distributable Scala packages.
+* [Ammonite](http://lihaoyi.github.io/Ammonite/) - Ammonite is a collection of Scala libraries intended to improve the experience of using Scala as an system shell.
+* [sbt-robovm](https://github.com/roboscala/sbt-robovm) - An sbt plugin for iOS development in Scala
 
 ## XML / HTML
 
 *Xml and Html generation and processing*
 
-* [Scalatags ★ 313 ⧗ 0](https://github.com/lihaoyi/scalatags) - Write html as scala code and have your ide syntax check it.
+* [Scalatags](https://github.com/lihaoyi/scalatags) - Write html as scala code and have your ide syntax check it.
 
 ## Learning Scala
 
 *Nice books, blogs and other resources to learn Scala*
 
-* [Scala in Depth ★ ? ⧗ ?](http://www.manning.com/suereth/) - None
-* [The Neophyte's Guide to Scala ★ ? ⧗ ?](http://danielwestheide.com/scala/neophytes.html) - None
+* [The Neophyte's Guide to Scala](http://danielwestheide.com/scala/neophytes.html)
+* [Scala in Depth](http://www.manning.com/suereth/)
+* [Scala Exercises](http://scala-exercises.47deg.com/)
+
+## JavaScript
+
+*JavaScript generation and interop libraries.*
+
+* [Scala.js](http://www.scala-js.org/) ([repo](https://github.com/scala-js/scala-js)) - Scala to JavaScript compiler
+* [js-scala](https://github.com/js-scala/js-scala) - JavaScript as an embedded DSL in Scala
+* [scala-js-fiddle](http://www.scala-js-fiddle.com/) ([repo](https://github.com/lihaoyi/scala-js-fiddle)) - Browser-based Scala.js playground
 
 ## Tools
 
-* [Abide ★ 169 ⧗ 1](https://github.com/scala/scala-abide) - Library for quick scala code checking and validation
-* [Codacy ★ ? ⧗ ?](https://www.codacy.com/) - Automated Code Reviews for Scala
-* [**Gitbucket ★ 4381 ⧗ 0**](https://github.com/takezoe/gitbucket) - The easily installable GitHub clone powered by Scala
-* [Scalastyle ★ 293 ⧗ 7](https://github.com/scalastyle/scalastyle) - Scala style checker.
-* [Scapegoat ★ 94 ⧗ 7](https://github.com/sksamuel/scalac-scapegoat-plugin) - Scala compiler plugin for static code analysis
-* [Scoverage ★ ? ⧗ ?](https://github.com/scoverage) - Scala Code Coverage tool
-* [Wartremover ★ 366 ⧗ 4](https://github.com/puffnfresh/wartremover) - Wartremover a flexible Scala code linting tool
+* [sbt](http://www.scala-sbt.org/) ([repo](https://github.com/sbt/sbt)) - The interactive build tool for Scala
+* [Scalastyle](https://github.com/scalastyle/scalastyle) – Scala style checker.
+* [Codacy](https://www.codacy.com/) - Automated Code Reviews for Scala
+* [Wartremover](https://github.com/puffnfresh/wartremover) - Wartremover a flexible Scala code linting tool
+* [Abide](https://github.com/scala/scala-abide) - Library for quick scala code checking and validation
+* [Scoverage](https://github.com/scoverage) - Scala Code Coverage tool
+* [Gitbucket](https://github.com/takezoe/gitbucket) - The easily installable GitHub clone powered by Scala
+* [Scapegoat](https://github.com/sksamuel/scalac-scapegoat-plugin) - Scala compiler plugin for static code analysis
+* [Scalariform](https://github.com/daniel-trinh/scalariform) - Scala source code formatter
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -35,22 +35,22 @@ A community driven list of useful Scala libraries, frameworks and software. This
 
 *Database access libraries in Scala.*
 
-* [*Activate ★ 249 ⧗ 4*](https://github.com/fwbrasil/activate) - Pluggable object persistence in Scala.
-* [*doobie ★ 263 ⧗ 1*](https://github.com/tpolecat/doobie) - Pure functional JDBC layer for Scala.
-* [*Elastic4s ★ 401 ⧗ 0*](https://github.com/sksamuel/elastic4s) - A scala DSL / reactive client for Elasticsearch
-* [*MapperDao ★ 2 ⧗ 75*](https://github.com/kostaskougios/mapperdao) - An ORM library for oracle, mysql, mssql, and postgresql
-* [*Phantom ★ 278 ⧗ 0*](https://github.com/websudos/phantom) - Reactive type safe Scala driver for Apache Cassandra.
-* [*PostgreSQL and MySQL async ★ 647 ⧗ 0*](https://github.com/mauricio/postgresql-async) - Async database drivers to talk to PostgreSQL and MySQL in Scala.
+* [Activate ★ 249 ⧗ 4](https://github.com/fwbrasil/activate) - Pluggable object persistence in Scala.
+* [doobie ★ 263 ⧗ 1](https://github.com/tpolecat/doobie) - Pure functional JDBC layer for Scala.
+* [Elastic4s ★ 401 ⧗ 0](https://github.com/sksamuel/elastic4s) - A scala DSL / reactive client for Elasticsearch
+* [MapperDao ★ 2 ⧗ 76](https://github.com/kostaskougios/mapperdao) - An ORM library for oracle, mysql, mssql, and postgresql
+* [Phantom ★ 278 ⧗ 0](https://github.com/websudos/phantom) - Reactive type safe Scala driver for Apache Cassandra.
+* [**PostgreSQL and MySQL async ★ 647 ⧗ 0**](https://github.com/mauricio/postgresql-async) - Async database drivers to talk to PostgreSQL and MySQL in Scala.
 * [ReactiveCouchbase ★ ? ⧗ ?](http://reactivecouchbase.org/) - Reactive Scala Driver for Couchbase. Also includes a Play plug-in. An official plug-in is also in development.
-* [*ReactiveMongo ★ 573 ⧗ 3*](https://github.com/ReactiveMongo/ReactiveMongo) - Reactive Scala Driver for MongoDB.
-* [*ReactiveNeo ★ 21 ⧗ 1*](https://github.com/websudos/reactiveneo) - Reactive type-safe Scala driver for Neo4J.
+* [**ReactiveMongo ★ 573 ⧗ 3**](https://github.com/ReactiveMongo/ReactiveMongo) - Reactive Scala Driver for MongoDB.
+* [ReactiveNeo ★ 21 ⧗ 1](https://github.com/websudos/reactiveneo) - Reactive type-safe Scala driver for Neo4J.
 * [Salat ★ ? ⧗ ?](https://github.com/novus/salat/) - ORM for MongoDB. A related Play-plugin is also available.
-* [*Scala ActiveRecord ★ 229 ⧗ 3*](https://github.com/aselab/scala-activerecord) - ORM library for scala, inspired by ActiveRecord of Ruby on Rails.
-* [*ScalikeJDBC ★ 474 ⧗ 1*](https://github.com/scalikejdbc/scalikejdbc) - A tidy SQL-based DB access library for Scala developers.
-* [*Slick ★ 1261 ⧗ 0*](https://github.com/slick/slick) - Modern database query and access library for Scala.
-* [*Sorm ★ 178 ⧗ 2*](https://github.com/sorm/sorm) - A functional boilerplate-free Scala ORM.
-* [*Squeryl ★ 439 ⧗ 2*](https://github.com/squeryl/squeryl) - A Scala DSL for talking with databases with minimum verbosity and maximum type safety.
-* [*Tepkin ★ 81 ⧗ 5*](https://github.com/fehmicansaglam/tepkin) - Reactive MongoDB Driver for Scala built on top of Akka IO and Akka Streams.
+* [Scala ActiveRecord ★ 229 ⧗ 3](https://github.com/aselab/scala-activerecord) - ORM library for scala, inspired by ActiveRecord of Ruby on Rails.
+* [ScalikeJDBC ★ 474 ⧗ 1](https://github.com/scalikejdbc/scalikejdbc) - A tidy SQL-based DB access library for Scala developers.
+* [**Slick ★ 1261 ⧗ 0**](https://github.com/slick/slick) - Modern database query and access library for Scala.
+* [Sorm ★ 178 ⧗ 2](https://github.com/sorm/sorm) - A functional boilerplate-free Scala ORM.
+* [Squeryl ★ 439 ⧗ 2](https://github.com/squeryl/squeryl) - A Scala DSL for talking with databases with minimum verbosity and maximum type safety.
+* [Tepkin ★ 81 ⧗ 5](https://github.com/fehmicansaglam/tepkin) - Reactive MongoDB Driver for Scala built on top of Akka IO and Akka Streams.
 
 ## Graphical User Interfaces
 
@@ -62,124 +62,124 @@ A community driven list of useful Scala libraries, frameworks and software. This
 
 *Scala frameworks for web development.*
 
-* [*Chaos ★ 141 ⧗ 3*](https://github.com/mesosphere/chaos) - A lightweight framework for writing REST services in Scala.
+* [Chaos ★ 141 ⧗ 3](https://github.com/mesosphere/chaos) - A lightweight framework for writing REST services in Scala.
 * [Colossus ★ ? ⧗ ?](http://tumblr.github.io/colossus/) - lightweight framework for building high-performance applications in Scala that require non-blocking network I/O.
-* [*Finatra ★ 840 ⧗ 0*](https://github.com/twitter/finatra) - A sinatra-inspired web framework for scala, running on top of Finagle.
-* [*Lift ★ 905 ⧗ 2*](https://github.com/lift/framework) - Secure and powerful full stack web framework ([discussion](https://github.com/lauris/awesome-scala/pull/19)).
-* [*Play ★ 6561 ⧗ 0*](https://github.com/playframework/playframework) - Makes it easy to build scalable, fast and real-time web applications with Java & Scala.
-* [*Reactive ★ 187 ⧗ 34*](https://github.com/nafg/reactive) - FRP and web abstractions, which can be plugged into any web framework (currently only has bindings for Lift).
-* [*Scalatra ★ 1705 ⧗ 0*](https://github.com/scalatra/scalatra) - Tiny Scala high-performance, async web framework, inspired by Sinatra.
-* [*Skinny Framework ★ 434 ⧗ 0*](https://github.com/skinny-framework/skinny-framework) - A full-stack web app framework upon Scalatra for rapid Development in Scala.
+* [**Finatra ★ 840 ⧗ 0**](https://github.com/twitter/finatra) - A sinatra-inspired web framework for scala, running on top of Finagle.
+* [**Lift ★ 905 ⧗ 2**](https://github.com/lift/framework) - Secure and powerful full stack web framework ([discussion](https://github.com/lauris/awesome-scala/pull/19)).
+* [**Play ★ 6561 ⧗ 0**](https://github.com/playframework/playframework) - Makes it easy to build scalable, fast and real-time web applications with Java & Scala.
+* [Reactive ★ 187 ⧗ 34](https://github.com/nafg/reactive) - FRP and web abstractions, which can be plugged into any web framework (currently only has bindings for Lift).
+* [**Scalatra ★ 1705 ⧗ 0**](https://github.com/scalatra/scalatra) - Tiny Scala high-performance, async web framework, inspired by Sinatra.
+* [Skinny Framework ★ 434 ⧗ 0](https://github.com/skinny-framework/skinny-framework) - A full-stack web app framework upon Scalatra for rapid Development in Scala.
 * [Socko ★ ? ⧗ ?](http://sockoweb.org/) - An embedded Scala web server powered by Netty networking and Akka processing.
-* [*Spray ★ 2003 ⧗ 0*](https://github.com/spray/spray) - A suite of scala libraries for building and consuming RESTful web services on top of Akka.
-* [*Unfiltered ★ 592 ⧗ 0*](https://github.com/unfiltered/unfiltered) - A modular set of unopinionated primitives for servicing HTTP and WebSocket requests in Scala.
+* [**Spray ★ 2003 ⧗ 0**](https://github.com/spray/spray) - A suite of scala libraries for building and consuming RESTful web services on top of Akka.
+* [**Unfiltered ★ 592 ⧗ 0**](https://github.com/unfiltered/unfiltered) - A modular set of unopinionated primitives for servicing HTTP and WebSocket requests in Scala.
 * [Xitrum ★ ? ⧗ ?](http://xitrum-framework.github.io/) - An async and clustered Scala web framework and HTTP(S) server fusion on top of Netty, Akka, and Hazelcast.
 
 ## i18n
 
 *Scala libraries for i18n.*
 
-* [*scala-xgettext ★ 13 ⧗ 53*](https://github.com/xitrum-framework/scala-xgettext) - A compiler plugin that acts like GNU xgettext command to extract i18n strings in Scala source code files to Gettext .po file.
-* [*Scaposer ★ 24 ⧗ 10*](https://github.com/xitrum-framework/scaposer) - GNU Gettext .po file loader for Scala.
+* [scala-xgettext ★ 13 ⧗ 53](https://github.com/xitrum-framework/scala-xgettext) - A compiler plugin that acts like GNU xgettext command to extract i18n strings in Scala source code files to Gettext .po file.
+* [Scaposer ★ 24 ⧗ 10](https://github.com/xitrum-framework/scaposer) - GNU Gettext .po file loader for Scala.
 
 ## Authentication
 
 *Libraries for implementing authentications schemes.*
 
-* [*play-pac4j ★ 6 ⧗ 11*](https://github.com/leleuj/play-pac4j) - Profile & Authentication Client in Scala for CAS, OAuth, OpenID, SAML & HTTP protocols and Play 2.x framework.
-* [*play-silhouette ★ 327 ⧗ 0*](https://github.com/mohiva/play-silhouette) - Authentication library for Play Framework applications that supports several authentication methods, including OAuth1, OAuth2, OpenID, Credentials or custom authentication schemes.
-* [*play2-auth ★ 478 ⧗ 2*](https://github.com/t2v/play2-auth) - Play2.x Authentication and Authorization module.
-* [*scala-oauth2-provider ★ 226 ⧗ 3*](https://github.com/nulab/scala-oauth2-provider) - OAuth 2.0 server-side implementation written in Scala.
-* [*SecureSocial ★ 1105 ⧗ 2*](https://github.com/jaliss/securesocial) - A module that provides OAuth, OAuth2 and OpenID authentication for Play Framework applications.
+* [play-pac4j ★ 6 ⧗ 11](https://github.com/leleuj/play-pac4j) - Profile & Authentication Client in Scala for CAS, OAuth, OpenID, SAML & HTTP protocols and Play 2.x framework.
+* [play-silhouette ★ 327 ⧗ 0](https://github.com/mohiva/play-silhouette) - Authentication library for Play Framework applications that supports several authentication methods, including OAuth1, OAuth2, OpenID, Credentials or custom authentication schemes.
+* [play2-auth ★ 478 ⧗ 2](https://github.com/t2v/play2-auth) - Play2.x Authentication and Authorization module.
+* [scala-oauth2-provider ★ 226 ⧗ 3](https://github.com/nulab/scala-oauth2-provider) - OAuth 2.0 server-side implementation written in Scala.
+* [**SecureSocial ★ 1105 ⧗ 2**](https://github.com/jaliss/securesocial) - A module that provides OAuth, OAuth2 and OpenID authentication for Play Framework applications.
 
 ## Testing
 
 *Libraries for code testing.*
 
 * [Gatling ★ ? ⧗ ?](http://gatling-tool.org/) - Async Scala-Akka-Netty based Stress Tool.
-* [*ScalaCheck ★ 832 ⧗ 1*](https://github.com/rickynils/scalacheck) - Property-based testing for Scala.
+* [**ScalaCheck ★ 832 ⧗ 1**](https://github.com/rickynils/scalacheck) - Property-based testing for Scala.
 * [ScalaMeter ★ ? ⧗ ?](https://scalameter.github.io/) - Performance &  memory footprint measuring, regression testing.
 * [ScalaMock ★ ? ⧗ ?](http://scalamock.org) - Scala native mocking framework
-* [*ScalaTest ★ 269 ⧗ 2*](https://github.com/scalatest/scalatest) - A testing tool for Scala and Java developers.
-* [*Scalive ★ 114 ⧗ 29*](https://github.com/xitrum-framework/scalive) - Connect a Scala REPL to running JVM processes without any prior setup; this library is used for inspecting systems in production mode.
-* [*Specs2 ★ 443 ⧗ 0*](https://github.com/etorreborre/specs2) - Software Specifications for Scala.
-* [*µTest ★ 117 ⧗ 4*](https://github.com/lihaoyi/utest) - A tiny, portable testing library for Scala.
+* [ScalaTest ★ 269 ⧗ 2](https://github.com/scalatest/scalatest) - A testing tool for Scala and Java developers.
+* [Scalive ★ 114 ⧗ 29](https://github.com/xitrum-framework/scalive) - Connect a Scala REPL to running JVM processes without any prior setup; this library is used for inspecting systems in production mode.
+* [Specs2 ★ 443 ⧗ 0](https://github.com/etorreborre/specs2) - Software Specifications for Scala.
+* [µTest ★ 117 ⧗ 4](https://github.com/lihaoyi/utest) - A tiny, portable testing library for Scala.
 
 ## JSON Manipulation
 
 *Libraries for work with json.*
 
 * [argonaut ★ ? ⧗ ?](http://argonaut.io/) - Purely Functional JSON in Scala.
-* [*jackson-module-scala ★ 224 ⧗ 8*](https://github.com/FasterXML/jackson-module-scala) - Add-on module for Jackson to support Scala-specific datatypes.
-* [*json4s ★ 467 ⧗ 1*](https://github.com/json4s/json4s) - Project aims to provide a single AST to be used by other scala json libraries.
+* [jackson-module-scala ★ 224 ⧗ 8](https://github.com/FasterXML/jackson-module-scala) - Add-on module for Jackson to support Scala-specific datatypes.
+* [json4s ★ 467 ⧗ 1](https://github.com/json4s/json4s) - Project aims to provide a single AST to be used by other scala json libraries.
 * [play-json ★ ? ⧗ ?](https://github.com/playframework/playframework/tree/master/framework/src/play-json) - Flexible and powerful JSON manipulation, validation and serialization, with no reflection at runtime.
-* [*scalajack ★ 62 ⧗ 4*](https://github.com/gzoller/ScalaJack) - Fast 'n easy JSON serialization with optional MongoDB support.  Uses Jackson under the hood.
-* [*spray-json ★ 403 ⧗ 2*](https://github.com/spray/spray-json) - Lightweight, clean and efficient JSON implementation in Scala.
+* [scalajack ★ 62 ⧗ 4](https://github.com/gzoller/ScalaJack) - Fast 'n easy JSON serialization with optional MongoDB support.  Uses Jackson under the hood.
+* [spray-json ★ 403 ⧗ 2](https://github.com/spray/spray-json) - Lightweight, clean and efficient JSON implementation in Scala.
 
 ## Serialization
 
 *Libraries for serializing and deserializing data for storage or transport.*
 
-* [*Chill ★ 285 ⧗ 6*](https://github.com/twitter/chill) - Extensions for the Kryo serialization library to ease configuration in systems like Hadoop and Storm.
-* [*Pickling ★ 632 ⧗ 1*](https://github.com/scala/pickling) - Fast, customizable, boilerplate-free pickling support.
+* [Chill ★ 285 ⧗ 6](https://github.com/twitter/chill) - Extensions for the Kryo serialization library to ease configuration in systems like Hadoop and Storm.
+* [**Pickling ★ 632 ⧗ 1**](https://github.com/scala/pickling) - Fast, customizable, boilerplate-free pickling support.
 * [ScalaPB ★ ? ⧗ ?](http://trueaccord.github.io/ScalaPB/) - A Protocol Buffer generator for Scala.
-* [*scodec ★ 301 ⧗ 4*](https://github.com/scodec/scodec) - A combinator library for working with binary data.
+* [scodec ★ 301 ⧗ 4](https://github.com/scodec/scodec) - A combinator library for working with binary data.
 * [Scrooge ★ ? ⧗ ?](http://twitter.github.io/scrooge/) - An Apache Thrift code generator for Scala.
-* [*validation ★ 101 ⧗ 7*](https://github.com/jto/validation) - Advanced validation & serialization for JSON, HTML form data, etc, with no reflection at runtime.
+* [validation ★ 101 ⧗ 7](https://github.com/jto/validation) - Advanced validation & serialization for JSON, HTML form data, etc, with no reflection at runtime.
 * [µPickle ★ ? ⧗ ?](http://lihaoyi.github.io/upickle-pprint/upickle/) - A lightweight serialization library for Scala that works in ScalaJS, allowing transfer of structured data between the JVM and JavaScript.
 
 ## Science and Data Analysis
 
 *Libraries for scientific computing, data analysis and numerical processing.*
 
-* [*Algebird ★ 955 ⧗ 0*](https://github.com/twitter/algebird) - Abstract Algebra for Scala.
+* [**Algebird ★ 955 ⧗ 0**](https://github.com/twitter/algebird) - Abstract Algebra for Scala.
 * [Axle ★ ? ⧗ ?](http://axle-lang.org) - Spire-based DSL for scientific cloud computing.
-* [*Breeze ★ 1087 ⧗ 0*](https://github.com/scalanlp/breeze) - Breeze is a numerical processing library for Scala.
-* [*Chalk ★ 165 ⧗ 0*](https://github.com/scalanlp/chalk) - Chalk is a natural language processing library.
-* [*FACTORIE ★ 322 ⧗ 4*](https://github.com/factorie/factorie) - A toolkit for deployable probabilistic modeling, implemented as a software library in Scala.
-* [*Figaro ★ 201 ⧗ 8*](https://github.com/p2t2/figaro) - Figaro is a probabilistic programming language that supports development of very rich probabilistic models.
-* [*MGO ★ 9 ⧗ 96*](https://github.com/romainreuillon/mgo) - Modular multi-objective evolutionary algorithm optimization library enforcing immutability.
+* [**Breeze ★ 1087 ⧗ 0**](https://github.com/scalanlp/breeze) - Breeze is a numerical processing library for Scala.
+* [Chalk ★ 165 ⧗ 0](https://github.com/scalanlp/chalk) - Chalk is a natural language processing library.
+* [FACTORIE ★ 322 ⧗ 4](https://github.com/factorie/factorie) - A toolkit for deployable probabilistic modeling, implemented as a software library in Scala.
+* [Figaro ★ 201 ⧗ 8](https://github.com/p2t2/figaro) - Figaro is a probabilistic programming language that supports development of very rich probabilistic models.
+* [MGO ★ 9 ⧗ 96](https://github.com/romainreuillon/mgo) - Modular multi-objective evolutionary algorithm optimization library enforcing immutability.
 * [MLLib ★ ? ⧗ ?](https://spark.apache.org/mllib/) - Machine Learning framework for Spark
-* [*OpenMOLE ★ 9 ⧗ 28*](https://github.com/ISCPIF/openmole) - OpenMOLE (Open MOdeL Experiment) is a workflow engine designed to leverage the computing power of distributed execution environments for naturally parallel processes.
-* [*PredictionIO ★ 7422 ⧗ 0*](https://github.com/PredictionIO/PredictionIO) - machine learning server for developers and data scientists. Built on Apache Spark, HBase and Spray
-* [*Saddle ★ 324 ⧗ 8*](https://github.com/saddle/saddle) - A minimalist port of Pandas to Scala
-* [*Spire ★ 737 ⧗ 4*](https://github.com/non/spire) - Powerful new number types and numeric abstractions for Scala.
-* [*Squants ★ 206 ⧗ 0*](https://github.com/garyKeorkunian/squants) - The Scala API for Quantities, Units of Measure and Dimensional Analysis.
+* [OpenMOLE ★ 9 ⧗ 28](https://github.com/ISCPIF/openmole) - OpenMOLE (Open MOdeL Experiment) is a workflow engine designed to leverage the computing power of distributed execution environments for naturally parallel processes.
+* [**PredictionIO ★ 7422 ⧗ 0**](https://github.com/PredictionIO/PredictionIO) - machine learning server for developers and data scientists. Built on Apache Spark, HBase and Spray
+* [Saddle ★ 324 ⧗ 8](https://github.com/saddle/saddle) - A minimalist port of Pandas to Scala
+* [**Spire ★ 737 ⧗ 4**](https://github.com/non/spire) - Powerful new number types and numeric abstractions for Scala.
+* [Squants ★ 206 ⧗ 0](https://github.com/garyKeorkunian/squants) - The Scala API for Quantities, Units of Measure and Dimensional Analysis.
 
 ## Big Data
 
 * [Scoobi] (https://github.com/nicta/scoobi) - Write type-safe Hadoop programs in idiomatic Scala way
 
-* [*BIDMach ★ 395 ⧗ 0*](https://github.com/BIDData/BIDMach) - CPU and GPU machine learning library, using JNI for GPU computation.
-* [*Gearpump ★ 314 ⧗ 1*](https://github.com/intel-hadoop/gearpump) - Lightweight real-time big data streaming engine
-* [*GridScale ★ 7 ⧗ 4*](https://github.com/romainreuillon/gridscale) - A Scala API for computing clusters and grids.
-* [*Scalding ★ 2184 ⧗ 1*](https://github.com/twitter/scalding) - A Scala binding for the Cascading abstraction of Hadoop MapReduce.
-* [*scoozie ★ 47 ⧗ 4*](https://github.com/klout/scoozie) - Scala DSL on top of Oozie XML.
+* [BIDMach ★ 395 ⧗ 0](https://github.com/BIDData/BIDMach) - CPU and GPU machine learning library, using JNI for GPU computation.
+* [Gearpump ★ 314 ⧗ 1](https://github.com/intel-hadoop/gearpump) - Lightweight real-time big data streaming engine
+* [GridScale ★ 7 ⧗ 4](https://github.com/romainreuillon/gridscale) - A Scala API for computing clusters and grids.
+* [**Scalding ★ 2184 ⧗ 1**](https://github.com/twitter/scalding) - A Scala binding for the Cascading abstraction of Hadoop MapReduce.
+* [scoozie ★ 47 ⧗ 4](https://github.com/klout/scoozie) - Scala DSL on top of Oozie XML.
 * [Scrunch ★ ? ⧗ ?](http://crunch.apache.org/scrunch.html) - A Scala wrapper for [Apache Crunch](http://crunch.apache.org/index.html) which provides a framework for writing, testing, and running MapReduce pipelines.
-* [*Shadoop ★ 7 ⧗ 134*](https://github.com/adamretter/shadoop) - A Scala DSL for Hadoop MapReduce.
+* [Shadoop ★ 7 ⧗ 134](https://github.com/adamretter/shadoop) - A Scala DSL for Hadoop MapReduce.
 * [Spark ★ ? ⧗ ?](http://spark.apache.org/) - Lightning fast cluster computing — up to 100x faster than Hadoop for iterative algorithms (memory caching) and up to 10x faster than Hadoop for single-pass MapReduce jobs. Compatible with YARN-enabled Hadoop clusters, can run on Mesos and in stand-alone mode as well.
-* [*Summingbird ★ 1522 ⧗ 1*](https://github.com/twitter/summingbird) - An implementation of the “lambda architecture” as a software abstraction — a single API for Hadoop and Storm.
+* [**Summingbird ★ 1522 ⧗ 1**](https://github.com/twitter/summingbird) - An implementation of the “lambda architecture” as a software abstraction — a single API for Hadoop and Storm.
 
 ## Functional Reactive Programming
 
 *Event streams, signals, observables, etc.*
 
-* [*Monifu ★ 147 ⧗ 4*](https://github.com/monifu/monifu) - Extensions to Scala’s standard library for multi-threading primitives and functional reactive programming. Scala.js compatible.
-* [*Reactive Collections ★ 71 ⧗ 34*](https://github.com/storm-enroute/reactive-collections) - A library that incorporates event streams and signals with specialized collections called reactive containers, and expresses concurrency using isolates and channels.
-* [*RxScala ★ 280 ⧗ 0*](https://github.com/ReactiveX/RxScala) - Reactive Extensions for Scala – a library for composing asynchronous and event-based programs using observable sequences
-* [*scala.frp ★ 17 ⧗ 112*](https://github.com/dylemma/scala.frp) - Functional Reactive Programming for Scala (event streams).
-* [*Scala.Rx ★ 518 ⧗ 3*](https://github.com/lihaoyi/scala.rx) - An experimental library for Functional Reactive Programming in Scala (reactive variables). Scala.js compatible.
+* [Monifu ★ 147 ⧗ 4](https://github.com/monifu/monifu) - Extensions to Scala’s standard library for multi-threading primitives and functional reactive programming. Scala.js compatible.
+* [Reactive Collections ★ 71 ⧗ 34](https://github.com/storm-enroute/reactive-collections) - A library that incorporates event streams and signals with specialized collections called reactive containers, and expresses concurrency using isolates and channels.
+* [RxScala ★ 280 ⧗ 1](https://github.com/ReactiveX/RxScala) - Reactive Extensions for Scala – a library for composing asynchronous and event-based programs using observable sequences
+* [scala.frp ★ 17 ⧗ 112](https://github.com/dylemma/scala.frp) - Functional Reactive Programming for Scala (event streams).
+* [**Scala.Rx ★ 518 ⧗ 3**](https://github.com/lihaoyi/scala.rx) - An experimental library for Functional Reactive Programming in Scala (reactive variables). Scala.js compatible.
 * [Vertx.io ★ ? ⧗ ?](http://vertx.io/) - A polyglot reactive application platform for the JVM which aims to be an alternative to node.js. Its concurrency model resembles actors. It supports [Scala](http://vertx.io/core_manual_scala.html), Clojure, Java, Javascript, Ruby, Groovy and Python.
 
 ## Modularization and Dependency Injection
 
 *Modularization of applications, dependency injection, etc.*
 
-* [*Domino ★ 27 ⧗ 0*](https://github.com/helgoboss/domino) - Write elegant OSGi bundle activators in Scala.
-* [*MacWire ★ 342 ⧗ 2*](https://github.com/adamw/macwire) - Scala Macro to generate wiring code for class instantiation. DI container replacement.
-* [*Scaldi ★ 171 ⧗ 2*](https://github.com/scaldi/scaldi) - Lightweight Scala Dependency Injection Library.
-* [*Sclasner ★ 7 ⧗ 163*](https://github.com/xitrum-framework/sclasner) - Scala classpath scanner.
-* [*SubCut ★ 377 ⧗ 15*](https://github.com/dickwall/subcut) - Scala Uniquely Bound Classes Under Traits.
+* [Domino ★ 27 ⧗ 0](https://github.com/helgoboss/domino) - Write elegant OSGi bundle activators in Scala.
+* [MacWire ★ 342 ⧗ 2](https://github.com/adamw/macwire) - Scala Macro to generate wiring code for class instantiation. DI container replacement.
+* [Scaldi ★ 171 ⧗ 2](https://github.com/scaldi/scaldi) - Lightweight Scala Dependency Injection Library.
+* [Sclasner ★ 7 ⧗ 163](https://github.com/xitrum-framework/sclasner) - Scala classpath scanner.
+* [SubCut ★ 377 ⧗ 15](https://github.com/dickwall/subcut) - Scala Uniquely Bound Classes Under Traits.
 
 ## Distributed Systems
 
@@ -187,55 +187,55 @@ A community driven list of useful Scala libraries, frameworks and software. This
 
 * [Akka ★ ? ⧗ ?](http://akka.io/) - A toolkit and runtime for building highly concurrent, distributed, and fault tolerant event-driven applications.
 * [Finagle ★ ? ⧗ ?](https://twitter.github.io/finagle/) - An extensible, protocol-agnostic RPC system designed for high performance and concurrency.
-* [*Glokka ★ 35 ⧗ 9*](https://github.com/xitrum-framework/glokka) - Library to register and lookup actors by names in an Akka cluster.
+* [Glokka ★ 35 ⧗ 9](https://github.com/xitrum-framework/glokka) - Library to register and lookup actors by names in an Akka cluster.
 
 ## Extensions
 
 *Scala extensions.*
 
-* [*Cassovary ★ 737 ⧗ 0*](https://github.com/twitter/cassovary) - A Scala library that is designed from the ground up for space efficiency, handling graphs with billions of nodes and edges.
-* [*Lamma ★ 42 ⧗ 4*](https://github.com/maxcellent/lamma) - A Scala date library for date and schedule generation.
+* [**Cassovary ★ 737 ⧗ 0**](https://github.com/twitter/cassovary) - A Scala library that is designed from the ground up for space efficiency, handling graphs with billions of nodes and edges.
+* [Lamma ★ 42 ⧗ 4](https://github.com/maxcellent/lamma) - A Scala date library for date and schedule generation.
 * [Log4s ★ ? ⧗ ?](http://log4s.org) - Fast, Scala-friendly logging bindings on top of [SLF4J](http://slf4j.org/). Uses macros for extreme performance.
-* [*Resolvable ★ 24 ⧗ 15*](https://github.com/resolvable/resolvable) - A library to optimize fetching immutable data structures from several endpoints in several formats.
-* [*Scala Async ★ 514 ⧗ 0*](https://github.com/scala/async) - An asynchronous programming facility for Scala.
+* [Resolvable ★ 24 ⧗ 15](https://github.com/resolvable/resolvable) - A library to optimize fetching immutable data structures from several endpoints in several formats.
+* [**Scala Async ★ 514 ⧗ 0**](https://github.com/scala/async) - An asynchronous programming facility for Scala.
 * [Scala Blitz ★ ? ⧗ ?](http://scala-blitz.github.io/) - A library to speed up Scala collection operations by removing runtime overheads during compilation, and a custom data-parallel operation runtime.
 * [Scala Graph ★ ? ⧗ ?](http://www.scala-graph.org/) - A Scala library with basic graph functionality that seamlessly fits into the Scala standard collections library.
 * [Scalactic ★ ? ⧗ ?](http://www.scalactic.org/) - Small library of utilities related to quality that helps keeping code clear and correct.
-* [*Scalaz ★ 1979 ⧗ 0*](https://github.com/scalaz/scalaz) - An extension to the core Scala library for functional programming.
-* [*Shapeless ★ 1164 ⧗ 0*](https://github.com/milessabin/shapeless) - A type class and dependent type based generic programming library for Scala.
-* [*Twitter Util ★ 1223 ⧗ 0*](https://github.com/twitter/util) - General-purpose Scala libraries, including a future implementation and other concurrency tools.
+* [**Scalaz ★ 1979 ⧗ 0**](https://github.com/scalaz/scalaz) - An extension to the core Scala library for functional programming.
+* [**Shapeless ★ 1164 ⧗ 0**](https://github.com/milessabin/shapeless) - A type class and dependent type based generic programming library for Scala.
+* [**Twitter Util ★ 1224 ⧗ 0**](https://github.com/twitter/util) - General-purpose Scala libraries, including a future implementation and other concurrency tools.
 
 ## Misc
 
-* [*REPLesent ★ 148 ⧗ 0*](https://github.com/marconilanna/REPLesent) - A presentation tool built inside the Scala REPL. Runs code straight from your slides with a single keystroke.
+* [REPLesent ★ 148 ⧗ 0](https://github.com/marconilanna/REPLesent) - A presentation tool built inside the Scala REPL. Runs code straight from your slides with a single keystroke.
 
 ## Android
 
 *Scala libraries and wrappers for Android development.*
 
-* [*Android SDK Plugin for SBT ★ 347 ⧗ 0*](https://github.com/pfn/android-sdk-plugin) - An sbt plugin that adds tasks for developing Android applications.
-* [*Gradle Android Scala Plugin ★ 205 ⧗ 1*](https://github.com/saturday06/gradle-android-scala-plugin) - A gradle plugin that allows you to use Scala with Android
-* [*Macroid ★ 279 ⧗ 0*](https://github.com/macroid/macroid) - A modular functional UI language for Android.
-* [*Scaloid ★ 1671 ⧗ 0*](https://github.com/pocorall/scaloid) - Less painful Android development with Scala.
+* [Android SDK Plugin for SBT ★ 347 ⧗ 0](https://github.com/pfn/android-sdk-plugin) - An sbt plugin that adds tasks for developing Android applications.
+* [Gradle Android Scala Plugin ★ 205 ⧗ 1](https://github.com/saturday06/gradle-android-scala-plugin) - A gradle plugin that allows you to use Scala with Android
+* [Macroid ★ 279 ⧗ 0](https://github.com/macroid/macroid) - A modular functional UI language for Android.
+* [**Scaloid ★ 1671 ⧗ 0**](https://github.com/pocorall/scaloid) - Less painful Android development with Scala.
 
 ## HTTP
 
 *Scala libraries and wrappers for HTTP clients.*
 
-* [*Dispatch ★ 293 ⧗ 1*](https://github.com/dispatch/reboot) - Library for asynchronous HTTP interaction. It provides a Scala vocabulary for Java’s [async-http-client](https://github.com/AsyncHttpClient/async-http-client).
-* [*Finch.io ★ 364 ⧗ 1*](https://github.com/finagle/finch) - Purely Functional REST API atop of [Finagle](https://github.com/twitter/finagle).
-* [*Netcaty ★ 9 ⧗ 30*](https://github.com/ngocdaothanh/netcaty) - Simple net test client/server for Netty and Scala lovers.
-* [*Newman ★ 205 ⧗ 24*](https://github.com/stackmob/newman) - A REST DSL that tries to take the best from Dispatch, Finagle and Apache HttpClient. See [here](https://www.paypal-engineering.com/2014/02/13/hello-newman-a-rest-client-for-scala/) for rationale.
-* [*scalaj-http ★ 274 ⧗ 1*](https://github.com/scalaj/scalaj-http) - Simple scala wrapper for HttpURLConnection (including OAuth support).
-* [*Scalaxb ★ 171 ⧗ 5*](https://github.com/eed3si9n/scalaxb) - An XML data-binding tool for Scala that supports W3C XML Schema (xsd) and Web Services Description Language (wsdl) as the input file.
+* [Dispatch ★ 293 ⧗ 1](https://github.com/dispatch/reboot) - Library for asynchronous HTTP interaction. It provides a Scala vocabulary for Java’s [async-http-client](https://github.com/AsyncHttpClient/async-http-client).
+* [Finch.io ★ 364 ⧗ 1](https://github.com/finagle/finch) - Purely Functional REST API atop of [Finagle](https://github.com/twitter/finagle).
+* [Netcaty ★ 9 ⧗ 30](https://github.com/ngocdaothanh/netcaty) - Simple net test client/server for Netty and Scala lovers.
+* [Newman ★ 205 ⧗ 24](https://github.com/stackmob/newman) - A REST DSL that tries to take the best from Dispatch, Finagle and Apache HttpClient. See [here](https://www.paypal-engineering.com/2014/02/13/hello-newman-a-rest-client-for-scala/) for rationale.
+* [scalaj-http ★ 274 ⧗ 1](https://github.com/scalaj/scalaj-http) - Simple scala wrapper for HttpURLConnection (including OAuth support).
+* [Scalaxb ★ 171 ⧗ 5](https://github.com/eed3si9n/scalaxb) - An XML data-binding tool for Scala that supports W3C XML Schema (xsd) and Web Services Description Language (wsdl) as the input file.
 * [Spray ★ ? ⧗ ?](http://spray.io/) - Actor-based library for http interaction.
-* [*Tubesocks ★ 7 ⧗ 374*](https://github.com/softprops/tubesocks) - Library supporting bi-directional communication with websocket servers.
+* [Tubesocks ★ 7 ⧗ 374](https://github.com/softprops/tubesocks) - Library supporting bi-directional communication with websocket servers.
 
 ## Semantic Web
 
 *Scala libraries for interactions with the Web of Data, and other RDF tools.*
 
-* [*Banana-RDF ★ 153 ⧗ 1*](https://github.com/w3c/banana-rdf) - Scala-friendly abstractions for RDF and Linked Data technologies. Supports Jena, Sesame and native Scala.
+* [Banana-RDF ★ 153 ⧗ 1](https://github.com/w3c/banana-rdf) - Scala-friendly abstractions for RDF and Linked Data technologies. Supports Jena, Sesame and native Scala.
 
 ## Metrics and Monitoring
 
@@ -247,31 +247,31 @@ A community driven list of useful Scala libraries, frameworks and software. This
 
 *Scala libraries for creating parsers.*
 
-* [*atto ★ 57 ⧗ 6*](https://github.com/tpolecat/atto) - Pure functional incremental text parsing library for Scala, based on Attoparsec.
-* [*Parboiled2 ★ 343 ⧗ 0*](https://github.com/sirthias/parboiled2) - A Fast Parser Generator for Scala 2.10.3+.
-* [*Scala Parser Combinators ★ 78 ⧗ 0*](https://github.com/scala/scala-parser-combinators) - Scala Standard Parser Combinator Library.
+* [atto ★ 57 ⧗ 6](https://github.com/tpolecat/atto) - Pure functional incremental text parsing library for Scala, based on Attoparsec.
+* [Parboiled2 ★ 343 ⧗ 0](https://github.com/sirthias/parboiled2) - A Fast Parser Generator for Scala 2.10.3+.
+* [Scala Parser Combinators ★ 78 ⧗ 0](https://github.com/scala/scala-parser-combinators) - Scala Standard Parser Combinator Library.
 
 ## Sbt plugins
 
 *Sbt plugins to make your life easier.*
 
 * [Ammonite ★ ? ⧗ ?](http://lihaoyi.github.io/Ammonite/) - Ammonite is a collection of Scala libraries intended to improve the experience of using Scala as an system shell.
-* [*Sbt-BuildInfo ★ 151 ⧗ 2*](https://github.com/sbt/sbt-buildinfo) - Generates Scala source from build definition.
-* [*Sbt-Dependency-Graph ★ 359 ⧗ 0*](https://github.com/jrudolph/sbt-dependency-graph) - Create a dependency graph for your project.
-* [*Sbt-Eclipse ★ 487 ⧗ 3*](https://github.com/typesafehub/sbteclipse) - Create Eclipse project definitions from sbt builds.
-* [*sbt-ide-settings ★ 15 ⧗ 1*](https://github.com/Jetbrains/sbt-ide-settings) - SBT plugin for tweaking various IDE settings
-* [*Sbt-Idea ★ 940 ⧗ 0*](https://github.com/mpeltonen/sbt-idea) - Create IntelliJ IDEA project definitions from sbt builds (not needed from IntelliJ 14, it supports sbt/scala projects through the Scala plugin).
-* [*Sbt-Native-Packager ★ 439 ⧗ 2*](https://github.com/sbt/sbt-native-packager) - Bundle up Scala software for native packaging systems, like deb, rpm, homebrew, msi..
-* [*Sbt-One-Jar ★ 180 ⧗ 20*](https://github.com/sbt/sbt-onejar) - Packages your project using One-JAR™.
-* [*sbt-pack ★ 170 ⧗ 1*](https://github.com/xerial/sbt-pack) - A sbt plugin for creating distributable Scala packages.
-* [*Sbt-Revolver ★ 358 ⧗ 1*](https://github.com/spray/sbt-revolver) - Fork & Stop processes from sbt.
-* [*Sbt-Start-Script ★ 133 ⧗ 11*](https://github.com/sbt/sbt-start-script) - Create a "start" script to run the program.
-* [*Sbt-Sublime ★ 113 ⧗ 0*](https://github.com/orrsella/sbt-sublime) - Create Sublime Text projects with library dependencies sources
-* [*Sbt-Updates ★ 197 ⧗ 0*](https://github.com/rtimush/sbt-updates) - Shows sbt project's dependency updates.
-* [*Sbt-Versions ★ 7 ⧗ 0*](https://github.com/sksamuel/sbt-versions) - Plugin that checks for updated versions of your project's dependencies.
-* [*ScalaKata ★ 124 ⧗ 9*](https://github.com/MasseGuillaume/ScalaKata) - Scala playground & Documentation tool.
-* [*tut ★ 109 ⧗ 4*](https://github.com/tpolecat/tut) - Tool for writing documentation with typechecked examples.
-* [*xsbt-web-plugin ★ 288 ⧗ 4*](https://github.com/earldouglas/xsbt-web-plugin) - Build enterprise J2EE Web applications in Scala.
+* [Sbt-BuildInfo ★ 151 ⧗ 2](https://github.com/sbt/sbt-buildinfo) - Generates Scala source from build definition.
+* [Sbt-Dependency-Graph ★ 359 ⧗ 0](https://github.com/jrudolph/sbt-dependency-graph) - Create a dependency graph for your project.
+* [Sbt-Eclipse ★ 487 ⧗ 3](https://github.com/typesafehub/sbteclipse) - Create Eclipse project definitions from sbt builds.
+* [sbt-ide-settings ★ 15 ⧗ 1](https://github.com/Jetbrains/sbt-ide-settings) - SBT plugin for tweaking various IDE settings
+* [**Sbt-Idea ★ 940 ⧗ 0**](https://github.com/mpeltonen/sbt-idea) - Create IntelliJ IDEA project definitions from sbt builds (not needed from IntelliJ 14, it supports sbt/scala projects through the Scala plugin).
+* [Sbt-Native-Packager ★ 439 ⧗ 2](https://github.com/sbt/sbt-native-packager) - Bundle up Scala software for native packaging systems, like deb, rpm, homebrew, msi..
+* [Sbt-One-Jar ★ 180 ⧗ 20](https://github.com/sbt/sbt-onejar) - Packages your project using One-JAR™.
+* [sbt-pack ★ 170 ⧗ 1](https://github.com/xerial/sbt-pack) - A sbt plugin for creating distributable Scala packages.
+* [Sbt-Revolver ★ 358 ⧗ 1](https://github.com/spray/sbt-revolver) - Fork & Stop processes from sbt.
+* [Sbt-Start-Script ★ 133 ⧗ 11](https://github.com/sbt/sbt-start-script) - Create a "start" script to run the program.
+* [Sbt-Sublime ★ 113 ⧗ 0](https://github.com/orrsella/sbt-sublime) - Create Sublime Text projects with library dependencies sources
+* [Sbt-Updates ★ 197 ⧗ 0](https://github.com/rtimush/sbt-updates) - Shows sbt project's dependency updates.
+* [Sbt-Versions ★ 7 ⧗ 0](https://github.com/sksamuel/sbt-versions) - Plugin that checks for updated versions of your project's dependencies.
+* [ScalaKata ★ 124 ⧗ 9](https://github.com/MasseGuillaume/ScalaKata) - Scala playground & Documentation tool.
+* [tut ★ 109 ⧗ 4](https://github.com/tpolecat/tut) - Tool for writing documentation with typechecked examples.
+* [xsbt-web-plugin ★ 288 ⧗ 4](https://github.com/earldouglas/xsbt-web-plugin) - Build enterprise J2EE Web applications in Scala.
 * [Zeppelin ★ ? ⧗ ?](http://zeppelin-project.org/) - Scala and Spark Notebook (like IPython Notebook)
 
 ## Other
@@ -284,7 +284,7 @@ A community driven list of useful Scala libraries, frameworks and software. This
 
 *Xml and Html generation and processing*
 
-* [*Scalatags ★ 313 ⧗ 0*](https://github.com/lihaoyi/scalatags) - Write html as scala code and have your ide syntax check it.
+* [Scalatags ★ 313 ⧗ 0](https://github.com/lihaoyi/scalatags) - Write html as scala code and have your ide syntax check it.
 
 ## Learning Scala
 
@@ -295,13 +295,13 @@ A community driven list of useful Scala libraries, frameworks and software. This
 
 ## Tools
 
-* [*Abide ★ 169 ⧗ 1*](https://github.com/scala/scala-abide) - Library for quick scala code checking and validation
+* [Abide ★ 169 ⧗ 1](https://github.com/scala/scala-abide) - Library for quick scala code checking and validation
 * [Codacy ★ ? ⧗ ?](https://www.codacy.com/) - Automated Code Reviews for Scala
-* [*Gitbucket ★ 4381 ⧗ 0*](https://github.com/takezoe/gitbucket) - The easily installable GitHub clone powered by Scala
-* [*Scalastyle ★ 293 ⧗ 7*](https://github.com/scalastyle/scalastyle) - Scala style checker.
-* [*Scapegoat ★ 94 ⧗ 7*](https://github.com/sksamuel/scalac-scapegoat-plugin) - Scala compiler plugin for static code analysis
+* [**Gitbucket ★ 4381 ⧗ 0**](https://github.com/takezoe/gitbucket) - The easily installable GitHub clone powered by Scala
+* [Scalastyle ★ 293 ⧗ 7](https://github.com/scalastyle/scalastyle) - Scala style checker.
+* [Scapegoat ★ 94 ⧗ 7](https://github.com/sksamuel/scalac-scapegoat-plugin) - Scala compiler plugin for static code analysis
 * [Scoverage ★ ? ⧗ ?](https://github.com/scoverage) - Scala Code Coverage tool
-* [*Wartremover ★ 366 ⧗ 4*](https://github.com/puffnfresh/wartremover) - Wartremover a flexible Scala code linting tool
+* [Wartremover ★ 366 ⧗ 4](https://github.com/puffnfresh/wartremover) - Wartremover a flexible Scala code linting tool
 
 # Contributing
 

--- a/metadata.py
+++ b/metadata.py
@@ -32,9 +32,9 @@ import urllib2
 # we use these regexes when "parsing" README.md
 empty_regex = re.compile(r"^ *\n$")
 section_regex = re.compile(r"^## (.+)\n$")
-repo_regex = re.compile(r"^\* \[(?:\*\*)?([^*★]+[^ ★])(?: ★ ([^ ]+) ⧗ ([^ *]+))?(?:\*\*)?\]\((.+?)\)(?: (?:-|—|–) (.+))?\n$")
+repo_regex = re.compile(r"^\* (?:\*\*)?\[?([^*★]+[^ ★])(?: ★ ([^ ]+) ⧗ ([^ *]+))?\]\((.+?)\)(?:\*\*)?(?: (?:-|—|–) (.+))?\n$")
 end_regex = re.compile(r"^# .+\n$")
-github_regex = re.compile(r"^https://github.com/(.+?)/(.+)$")
+github_regex = re.compile(r"^https://github.com/(.+?)/(.+?)(?:/?)$")
 
 # some paths
 readme_path = 'README.md'
@@ -81,8 +81,10 @@ def output_repo(outf, name, stars, days, link, rdesc):
         title = name
     else:
         title = '%s ★ %s ⧗ %s' % (name, stars, days)
-    if popular: title = '**' + title + '**'
-    outf.write('* [%s](%s) - %s\n' % (title, link, rdesc))
+    if popular:
+        outf.write('* **[%s](%s)** - %s\n' % (title, link, rdesc))
+    else:
+        outf.write('* [%s](%s) - %s\n' % (title, link, rdesc))
 
 def flush_section(outf, section, sdesc, repos):
     print '  ' + section.strip()

--- a/metadata.py
+++ b/metadata.py
@@ -77,9 +77,10 @@ def query(owner, name):
 
 def output_repo(outf, name, stars, days, link, rdesc):
     popular = stars is not None and stars != "?" and stars >= 500
-    if stars is None: stars = '?'
-    if days is None: days = '?'
-    title = '%s ★ %s ⧗ %s' % (name, stars, days)
+    if stars is None and days is None:
+        title = name
+    else:
+        title = '%s ★ %s ⧗ %s' % (name, stars, days)
     if popular: title = '**' + title + '**'
     outf.write('* [%s](%s) - %s\n' % (title, link, rdesc))
 

--- a/metadata.py
+++ b/metadata.py
@@ -32,8 +32,7 @@ import urllib2
 # we use these regexes when "parsing" README.md
 empty_regex = re.compile(r"^ *\n$")
 section_regex = re.compile(r"^## (.+)\n$")
-#repo_regex = re.compile(r"^\* \[\*?([^*★]+[^ ★])(?: ★ ([^ ]+) ⧗ ([^ *]+))?\*?\]\((.+?)\) - (.+)\n$")
-repo_regex = re.compile(r"^\* \[\*?([^*★]+[^ ★])(?: ★ ([^ ]+) ⧗ ([^ *]+))?\*?\]\((.+?)\)(?: (?:-|—|–) (.+))?\n$")
+repo_regex = re.compile(r"^\* \[(?:\*\*)?([^*★]+[^ ★])(?: ★ ([^ ]+) ⧗ ([^ *]+))?(?:\*\*)?\]\((.+?)\)(?: (?:-|—|–) (.+))?\n$")
 end_regex = re.compile(r"^# .+\n$")
 github_regex = re.compile(r"^https://github.com/(.+?)/(.+)$")
 
@@ -69,9 +68,9 @@ def query(owner, name):
             u = urllib2.urlopen(req)
             j = json.load(u)
             t = datetime.datetime.strptime(j['updated_at'], "%Y-%m-%dT%H:%M:%SZ")
-            days = max((now - t).days, 0)
+            days = max(int((now - t).days), 0)
             print '    %s/%s: ok' % (owner, name)
-            return (j['stargazers_count'], days)
+            return (int(j['stargazers_count']), days)
         except urllib2.HTTPError, e:
             print '    %s/%s: FAILED' % (owner, name)
             return (None, None)
@@ -81,7 +80,7 @@ def output_repo(outf, name, stars, days, link, rdesc):
     if stars is None: stars = '?'
     if days is None: days = '?'
     title = '%s ★ %s ⧗ %s' % (name, stars, days)
-    if popular: title = '*' + title + '*'
+    if popular: title = '**' + title + '**'
     outf.write('* [%s](%s) - %s\n' % (title, link, rdesc))
 
 def flush_section(outf, section, sdesc, repos):

--- a/metadata.py
+++ b/metadata.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# by Erik Osheim
+#
+# Reads README.md, and writes a README.md.new. If the format of
+# README.md changes, this script may need modifications.
+#
+# Currently it rewrites each section, doing the following:
+#  1. alphabetizing
+#  2. querying GitHub for stars and days since active
+#  3. formatting the link title to show this info
+#  4. bolding projects with lots of stars
+#
+# Once README.md has the stars/days info in the links, the
+# repo_regex will need slight modification.
+#
+# In order to use GH authentication, create a file in this directory
+# called .access-token, whose contents are: "$user:$token" where $user
+# is your github username, and $token is a Personal Access Token.
+
+import base64
+import datetime
+import json
+import os.path
+import random
+import re
+import shutil
+import sys
+import urllib2
+
+# we use these regexes when "parsing" README.md
+empty_regex = re.compile(r"^ *\n$")
+section_regex = re.compile(r"^## (.+)\n$")
+#repo_regex = re.compile(r"^\* \[\*?([^*★]+[^ ★])(?: ★ ([^ ]+) ⧗ ([^ *]+))?\*?\]\((.+?)\) - (.+)\n$")
+repo_regex = re.compile(r"^\* \[\*?([^*★]+[^ ★])(?: ★ ([^ ]+) ⧗ ([^ *]+))?\*?\]\((.+?)\) (?:-|—|–) (.+)\n$")
+end_regex = re.compile(r"^# .+\n$")
+github_regex = re.compile(r"^https://github.com/(.+?)/(.+)$")
+
+# some paths
+readme_path = 'README.md'
+temp_path = 'README.md.new'
+
+# these will be updated if .access-token exists.
+user = None
+token = None
+
+# use fake to avoid hitting github API
+fake = True
+
+# whether to query all projects, or just those lacking scores/days.
+full_update = False
+
+# right now.
+now = datetime.datetime.now()
+
+# ask github for the number of stargazers, and days since last
+# activity, for the given github project.
+def query(owner, name):
+    if fake:
+        print '    %s/%s: ok' % (owner, name)
+        return (random.randint(1, 1000), random.randint(1, 300))
+    else:
+        try:
+            req = urllib2.Request('https://api.github.com/repos/%s/%s' % (owner, name))
+            if user is not None and token is not None:
+                b64 = base64.encodestring('%s:%s' % (user, token)).replace('\n', '')
+                req.add_header("Authorization", "Basic %s" % b64)
+            u = urllib2.urlopen(req)
+            j = json.load(u)
+            t = datetime.datetime.strptime(j['updated_at'], "%Y-%m-%dT%H:%M:%SZ")
+            days = max((now - t).days, 0)
+            print '    %s/%s: ok' % (owner, name)
+            return (j['stargazers_count'], days)
+        except urllib2.HTTPError, e:
+            print '    %s/%s: FAILED' % (owner, name)
+            return (None, None)
+
+def output_repo(outf, name, stars, days, link, rdesc):
+    popular = stars is not None and stars != "?" and stars >= 500
+    if stars is None: stars = '?'
+    if days is None: days = '?'
+    title = '%s ★ %s ⧗ %s' % (name, stars, days)
+    if popular: title = '*' + title + '*'
+    outf.write('* [%s](%s) - %s\n' % (title, link, rdesc))
+
+def flush_section(outf, section, sdesc, repos):
+    print '  ' + section.strip()
+    outf.write(section)
+    outf.write('\n')
+    if sdesc:
+        outf.write(sdesc)
+        outf.write('\n')
+    repos.sort(key=lambda t: t[0].lower())
+    for name, stars, days, link, rdesc in repos:
+        if not full_update and stars is not None and days is not None:
+            output_repo(outf, name, stars, days, link, rdesc)
+            continue
+
+        m = github_regex.match(link)
+        if not m:
+            print '    %s: not a repo' % link
+            output_repo(outf, name, stars, days, link, rdesc)
+            continue
+
+        stars, days = query(m.group(1), m.group(2))
+        output_repo(outf, name, stars, days, link, rdesc)
+    outf.write('\n')
+
+def run():
+    if full_update:
+        print 'querying for all entries'
+    else:
+        print 'querying for new entries only'
+
+    if fake:
+        print 'running in fake mode -- no GH queries will be made'
+
+    if os.path.exists('.access-token'):
+        global user, token
+        user, token = open('.access-token').read().strip().split(':')
+        print 'using Personal Access Token %s:%s' % (user, token)
+    else:
+        print 'no Personal Access Token found in .access-token'
+
+    inf = open(readme_path, 'r')
+    lines = list(inf)
+    inf.close()
+    print 'read %r' % readme_path
+
+    started = False
+    finished = False
+    section = None
+    sdesc = None
+    repos = []
+    outf = open(temp_path, 'w')
+
+    total_repos = 0
+
+    print 'writing %r' % temp_path
+    for line in lines:
+        if finished:
+            outf.write(line)
+        elif started:
+            if end_regex.match(line):
+                total_repos += len(repos)
+                flush_section(outf, section, sdesc, repos)
+                outf.write(line)
+                finished = True
+            elif empty_regex.match(line):
+                continue
+            elif section_regex.match(line):
+                total_repos += len(repos)
+                flush_section(outf, section, sdesc, repos)
+                section = line
+                sdesc = None
+                repos = []
+            else:
+                m = repo_regex.match(line)
+                if m:
+                    name, stars, days, link, rdesc = m.groups()
+                    repos.append((name, stars, days, link, rdesc))
+                elif sdesc is None:
+                    sdesc = line
+                else:
+                    raise Exception("cannot parse %r" % line)
+        else:
+            if section_regex.match(line):
+                section = line
+                started = True
+            else:
+                outf.write(line)
+    outf.close()
+    print 'wrote %d repos to %r' % (total_repos, temp_path)
+
+    print 'moving %r to %r' % (temp_path, readme_path)
+    shutil.move(temp_path, readme_path)
+
+if __name__ == "__main__":
+    #global fake, full_update
+
+    from optparse import OptionParser
+
+    parser = OptionParser()
+    parser.add_option("-f", "--fake", action="store_true", dest="fake",
+                      default=False, help="don't query github, use fake data")
+    parser.add_option("-u", "--update", action="store_true", dest="update",
+                      default=False, help="update all entries to newest data")
+
+    opts, _ = parser.parse_args()
+    fake = opts.fake
+    full_update = opts.update
+    run()

--- a/metadata.py
+++ b/metadata.py
@@ -33,7 +33,7 @@ import urllib2
 empty_regex = re.compile(r"^ *\n$")
 section_regex = re.compile(r"^## (.+)\n$")
 #repo_regex = re.compile(r"^\* \[\*?([^*★]+[^ ★])(?: ★ ([^ ]+) ⧗ ([^ *]+))?\*?\]\((.+?)\) - (.+)\n$")
-repo_regex = re.compile(r"^\* \[\*?([^*★]+[^ ★])(?: ★ ([^ ]+) ⧗ ([^ *]+))?\*?\]\((.+?)\) (?:-|—|–) (.+)\n$")
+repo_regex = re.compile(r"^\* \[\*?([^*★]+[^ ★])(?: ★ ([^ ]+) ⧗ ([^ *]+))?\*?\]\((.+?)\)(?: (?:-|—|–) (.+))?\n$")
 end_regex = re.compile(r"^# .+\n$")
 github_regex = re.compile(r"^https://github.com/(.+?)/(.+)$")
 


### PR DESCRIPTION
This commit updates README.md to include the number of stars a project
has, and days since last activity. These are represented using the
unicode symbols ★ and ⧗.

For example, "Spire ★ 737 ⧗ 2" means that Spire has 737 "stargazers"
and has had activity within the last two days. In other words, the
first number corresponds with popularity (larger is better) and the
second number corresponds with activity (lower is better). We bold the
titles of projects that have 500 or more stars.

We look for a GitHub Personal Access Token stored in ./access-token.
If found, this will allow more queries to be made (the limit for
anonymous users is 60/hour).

There are two ways to run the script:

  ./metadata.py

    This will update projects lacking metadata entirely, leaving
    everything else as-is. In this mode, no Personal Access Token
    is needed if only a few new projects are being added.

  ./metadata.py --update

    This will update all projects. We should run this periodically
    since projects will be adding stars over time, and projects'
    activity levels will change over time as well. This mode requires
    a Personal Access Token, since we already have 120 repositories
    (double the hourly limit for anonymous API access).

The script also supports a --fake option to allow testing without
accessing GitHub's API.

README.md has not been updated yet; the author seems to have exceeded
GitHub's authenticated rate limit during testing.