### PR TITLE
Add MoultingYAML library

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Projects with over 500 stargazers are in bold.
     - [Authorization](#authorization)
     - [Testing](#testing)
     - [JSON](#json)
+    - [YAML](#yaml)
     - [Serialization](#serialization)
     - [Science and Data Analysis](#science-and-data-analysis)
     - [Big Data](#big-data)
@@ -140,6 +141,12 @@ Projects with over 500 stargazers are in bold.
 * [scalajack ★ 65 ⧗ 27](https://github.com/gzoller/ScalaJack) - Fast 'n easy JSON serialization with optional MongoDB support.  Uses Jackson under the hood.
 * [sonofjson ★ 17 ⧗ 8](https://github.com/wspringer/sonofjson) - A Scala library for dealing with JSON in a way that makes it almost feel native. 
 * [spray-json ★ 446 ⧗ 3](https://github.com/spray/spray-json) - Lightweight, clean and efficient JSON implementation in Scala.
+
+## YAML
+
+*Libraries for work with YAML.*
+
+* [MoultingYAML ★ 6 ⧗ 29](https://github.com/jcazevedo/moultingyaml) - Type-class based YAML serialization and deserialization on top of SnakeYAML.
 
 ## Serialization
 


### PR DESCRIPTION
This PR adds the [MoultingYAML](https://github.com/jcazevedo/moultingyaml) library for working with YAML. There was no section for YAML libraries, so I added a new one after the JSON one. I also ran the metadata script and updated the link accordingly. The Op-Rabbit library was also updated as a result of the metadata script, but I didn't include that change in this PR, as it felt out of scope.