### PR TITLE
Added reactive-kafka Scala client and made Kafka bold 

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ Projects with over 500 stargazers are in bold.
 * [BIDMach ★ 458 ⧗ 0](https://github.com/BIDData/BIDMach) - CPU and GPU machine learning library, using JNI for GPU computation.
 * [Gearpump ★ 354 ⧗ 1](https://github.com/gearpump/gearpump) - Lightweight real-time big data streaming engine
 * [GridScale ★ 8 ⧗ 91](https://github.com/openmole/gridscale) - A Scala API for computing clusters and grids.
-* [Kafka](https://github.com/apache/kafka) - Kafka is a message broker project and aims to provide a unified, high-throughput, low-latency platform for handling real-time data feeds.
+* **[Kafka ★ 2800 ⧗ 1](https://github.com/apache/kafka)** - Kafka is a message broker project and aims to provide a unified, high-throughput, low-latency platform for handling real-time data feeds.
+* [Reactive-kafka ★ 427 ⧗ 1](https://github.com/akka/reactive-kafka) - Reactive Streams API for Apache Kafka.
 * **[Scalding ★ 2336 ⧗ 0](https://github.com/twitter/scalding)** - A Scala binding for the Cascading abstraction of Hadoop MapReduce.
 * [Scoobi ★ 475 ⧗ 2](https://github.com/nicta/scoobi) - Write type-safe Hadoop programs in idiomatic Scala way
 * [Scoozie ★ 54 ⧗ 14](https://github.com/klout/scoozie) - Scala DSL on top of Oozie XML


### PR DESCRIPTION
Wow, I could not believe that Kafka had not been added already. 

So i looked a little bit closer at the list and noticed that a really awesome Kafka client library was also not on the list as well. So here it is. 

The Reactive-kafka repo has just recently moved over Akka group due to its popularity and aweomeness.

And,  yes I am a totally biased user of the library.