### PR TITLE
Add 'Scala @LibHunt' to the 'Tools' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ Projects with over 500 stargazers are in bold.
 ## Tools
 
 * [Abide ★ 209 ⧗ 7](https://github.com/scala/scala-abide) - Library for quick scala code checking and validation
+* [Scala @LibHunt](https://scala.libhunt.com) - The go-to Scala Toolbox.
 * [Codacy](https://www.codacy.com/) - Automated Code Reviews for Scala
 * [Fastring ★ 73 ⧗ 4](https://github.com/Atry/fastring) - Extremely fast string formatting
 * **[Gitbucket ★ 5478 ⧗ 0](https://github.com/gitbucket/gitbucket)** - The easily installable GitHub clone powered by Scala


### PR DESCRIPTION
It is based to the awesome-scala list here plus some improvements. A decent UI/UX, ordering by popularity and dev activity, the ability to compare different libs.