### PR TITLE
Add Airframe, dependency injection library for Scala

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Projects with over 500 stargazers are in bold.
 
 *Modularization of applications, dependency injection, etc.*
 
+* [Airframe](https://github.com/wvlet/airframe) - Dependency injection library tailored to Scala.
 * [Cableguy ★ 1 ⧗ 22](https://github.com/akozhemiakin/cableguy) - Macro based compile time Dependency Injection library.
 * [Domino ★ 2 ⧗ 216](https://github.com/helgoboss/domino) - Write elegant OSGi bundle activators in Scala.
 * **[MacWire ★ 522 ⧗ 0](https://github.com/adamw/macwire)** - Scala Macro to generate wiring code for class instantiation. DI container replacement.


### PR DESCRIPTION
Please add Airframe https://github.com/wvlet/airframe, a dependency injection library tailored to Scala.