### PR TITLE
Add fm-flatfile link

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ Projects with over 500 stargazers are in bold.
 
 * [kantan.csv ★ 143 ⧗ 24](https://github.com/nrinaudo/kantan.csv) - CSV handling library for Scala with multiple backends.
 * [Scala-CSV ★ 365 ⧗ 1](https://github.com/tototoshi/scala-csv) - CSV Reader/Writer for Scala.
+* [fm-flatfile ★ 1 ⧗ 1](https://github.com/frugalmechanic/fm-flatfile) - Very flexible, Flat File (CSV, TSV, Excel, etc) Reader for Scala.
+
 
 ## Serialization
 


### PR DESCRIPTION
Very under-the-radar flat-file reader.  We got sick of having to deal with the various non-standard CSV files we would get, and ended up writing our own a few years ago.  It also has Excel (via apache poi) support  using the same conventions.