### PR TITLE
 Change Advanced Scala with Cats to Scala with Cats

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,13 +508,13 @@ Projects with over 500 stargazers are in bold.
 * [Scala Collections Cookbook](http://colobu.com/ScalaCollectionsCookbook/) - Scala collections introduction. written in Chinese.
 * [Scala Exercises](http://scala-exercises.47deg.com/) - Brings the popular Scala Koans to the web. Offering hundreds of solvable exercises organized into 42 categories covering the basics of the Scala language.
 * [Exercism - Scala Exercises](http://exercism.io/languages/scala/exercises) - Community-driven Scala exercises.
+* [Scala With Cats](https://underscore.io/books/scala-with-cats/) - Learn system architecture and design using the techniques of modern functional programming with [Cats](https://typelevel.org/cats/)
 * [Scala in Depth](https://www.manning.com/books/scala-in-depth) - None
 * [Scala school](https://twitter.github.io/scala_school/) - Scala school started as a series of lectures at Twitter to prepare experienced engineers to be productive Scala programmers.
 * [Essential Scala](https://underscore.io/books/essential-scala/) - None
 * [Scalera Blog](http://www.scalera.es) - Blog about Scala language and its environment (howto's, good practices, tips,...). Weekly posts written in both spanish and english
 * [The Neophyte's Guide to Scala](http://danielwestheide.com/scala/neophytes.html) - None
 * Resources by [Dr. Mark Lewis](http://www.cs.trinity.edu/~mlewis/) >> [Website](http://www.programmingusingscala.net/) | [Youtube Playlists](https://www.youtube.com/user/DrMarkCLewis/playlists)
-* [Advanced Scala With Cats](https://underscore.io/books/advanced-scala/) - Learn system architecture and design using the techniques of modern functional programming with [Cats](https://typelevel.org/cats/)
 * [Functional Programming for Mortals](https://leanpub.com/fpmortals/read) - None
 * [The Type Astronaut's Guide to Shapeless](https://underscore.io/books/shapeless-guide/) - None
 


### PR DESCRIPTION
Underscore.io renamed "Advanced Scala with Cats" to "Scala with Cats" and updated the contents of the book for Cats 1.0.0-RC1. The commit changes the name of the book and its respective link -
 the old link doesn't work anymore.
