### PR TITLE
Add fast-string-interpolator

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,7 @@ Projects with over 500 stargazers are in bold.
 * [Abide ★ 243 ⧗ 3](https://github.com/scala/scala-abide) - Library for quick scala code checking and validation
 * [Codacy](https://www.codacy.com/) - Automated Code Reviews for Scala
 * [Fastring ★ 97 ⧗ 2](https://github.com/Atry/fastring) - Extremely fast string formatting
+* [fast-string-interpolator ★ 24 ⧗ 0](https://github.com/Sizmek/fast-string-interpolator) - Scala macro that generates ultra-fast string interpolators
 * **[Gitbucket ★ 6296 ⧗ 0](https://github.com/gitbucket/gitbucket)** - The easily installable GitHub clone powered by Scala
 * [sbt](http://www.scala-sbt.org/) ([repo](https://github.com/sbt/sbt)) - The interactive build tool for Scala
 * [Scala @LibHunt](https://scala.libhunt.com) - The go-to Scala Toolbox.


### PR DESCRIPTION
fast-string-interpolator - is a Scala macro that generates ultra-fast string interpolators with benchmarks where it is compared with standard Scala interpolators, 3rd-party interpolators, Scala/Java string builders, and a string concatenation.
