### PR TITLE
Add Scalate

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ Projects with over 500 stargazers are in bold.
 
 * [Beard ★ 67 ⧗ 3](https://github.com/zalando/beard) - lightweight logicless templating engine inspired by Mustache
 * [Scalatags ★ 492 ⧗ 3](https://github.com/lihaoyi/scalatags) - Write html as scala code and have your IDE syntax check it.
+* [Scalate ★ 5164](https://github.com/scalate/scalate) - Scala based template engine which supports HAML, Mustache and JSP, Erb and Velocity style syntaxes
 * [Twirl ★ 324 ⧗ 3](https://github.com/playframework/twirl) - The Play Scala Template Compiler
 
 ## Tools


### PR DESCRIPTION
Recently, Scalate is [actively maintained](https://github.com/scalate/scalate/commits/master) (I am the current main maintainer of the project). Thus, it would be reasonable to have the library on the list.