### PR TITLE
Add dregex

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,7 @@ Projects with over 500 stargazers are in bold.
 ## Tools
 
 * [Codacy](https://www.codacy.com/) - Automated Code Reviews for Scala
+* [dregrex](https://github.com/marianobarrios/dregex) - Regular expression engine using deterministic finite automata. It supports some Perl-style features and yet retains linear matching time.
 * [Fastring ★ 97 ⧗ 2](https://github.com/Atry/fastring) - Extremely fast string formatting
 * [fast-string-interpolator ★ 24 ⧗ 0](https://github.com/Sizmek/fast-string-interpolator) - Scala macro that generates ultra-fast string interpolators
 * **[Gitbucket ★ 6296 ⧗ 0](https://github.com/gitbucket/gitbucket)** - The easily installable GitHub clone powered by Scala


### PR DESCRIPTION
Add dregex, a JVM library that implements a regular expression engine using deterministic finite automata (DFA). It supports some Perl-style features and yet retains linear matching time, and also offers set operations.