### PR TITLE
Awesome online courses list by Classpert

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,7 @@ Projects with over 500 stargazers are in bold.
 * [Clean, intuitive, unintrusive, boilerplate-free Scala API](https://github.com/propensive/rapture/blob/dev/doc/json.md)
 * [fast, flexible and intuitive JSON for Scala](http://www.lihaoyi.com/upickle/#uJson)
 * [Scala @LibHunt](https://scala.libhunt.com) - The go-to Scala Toolbox.
+* [List of Scala Online Courses](https://classpert.com/scala-programming) - A list of free and paid Scala online courses by Classpert, An online course search and comparison website
 
 ## Podcasts
 


### PR DESCRIPTION
This commit adds an awesome list of online courses by Classpert to the “Misc.” section. This list is a comprehensive selection of ~ 80 Scala online courses (free and paid) from top e-learning providers like Coursera, Pluralsight, Udemy, Edx, Treehouse, and Skillshare.