### PR TITLE
Add GH action for building+deploying readme

### DIFF
--- a/.github/workflows/build-readme.yml
+++ b/.github/workflows/build-readme.yml
@@ -1,0 +1,31 @@
+name: Build and push README to master
+
+on:
+  push:
+    branches: master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Create local changes
+      run: |
+        python -m pip install --upgrade pip
+        pip install pipenv
+        pipenv install
+        pipenv run python add-metadata.py
+    - name: Commit files
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git commit -am "Update README.md using automation"
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: master


### PR DESCRIPTION
I tried it on a private repo:
- Python setup works, I tried with a simple `print` script (but with Pipfile etc.)
- pushing the changes works, tried with `echo abc >> bla.txt`

As per the [docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#about-the-github_token-secret) the `secrets.GITHUB_TOKEN` is magically added by a Github Action.

@SethTisue @benash @lauris 