### PR TITLE
Add scala2plantuml

### DIFF
--- a/template.md
+++ b/template.md
@@ -720,6 +720,7 @@ Name | Description | GitHub Activity
 * [puffnfresh/wartremover](@ghRepo)
 * [sake92/stone](@ghRepo)
 * [sake92/scalajs-router](@ghRepo)
+* [BotTech/scala2plantuml](@ghRepo)
 
 ### Geospatial
 


### PR DESCRIPTION
There is also an sbt plugin so I wasn't sure if it should also go there. Scalafmt seems to be in both.

I'm guessing that there is no particular order to the list?