### PR TITLE
removed a name shadowing pitfall

### DIFF
--- a/add-metadata.py
+++ b/add-metadata.py
@@ -33,8 +33,8 @@ def github_table_row(repo):
     return f"{project_link} | {repo.description} | {stars_shield} {commit_shield}"
 
 
-def warn(str):
-    print(f"Warn: {str}", file=sys.stderr)
+def warn(msg):
+    print(f"Warn: {msg}", file=sys.stderr)
 
 
 def retrieve_repo(name):


### PR DESCRIPTION
**The problem**
There was a method which was taking as input a parameter called 'str'. But str is a built-in Python name and renaming it may bring up a situation where in a future one may call **str(argument)**, which should be a method call, but it would cause an error since str is no longer a method, but a variable..

**The solution**
Renamed the parameter to 'msg'