### PR TITLE
print -> warn

### DIFF
--- a/add-metadata.py
+++ b/add-metadata.py
@@ -41,7 +41,7 @@ def retrieve_repo(name):
     try:
         repo = g.get_repo(name)
     except Exception:
-        print(f"Error occured while getting {name} repo")
+        warn(f"Error occured while getting {name} repo")
         raise
     print('.', file=sys.stderr, end='', flush=True)
     check_freshness(repo)


### PR DESCRIPTION
Sorry, didn`t see at first that print is used to write to README.md. warn should be used instead