### PR TITLE
Remove [deeplearning4j/nd4s](@ghRepo)

### DIFF
--- a/template.md
+++ b/template.md
@@ -322,7 +322,6 @@ Name | Description | GitHub Activity
 * [anskarl/LoMRF](@ghRepo)
 * [openmole/mgo](@ghRepo)
 [MLLib](https://spark.apache.org/mllib/) | Machine Learning framework for Spark |
-* [deeplearning4j/nd4s](@ghRepo)
 * [SciScala/NDScala](@ghRepo)
 * [botkop/numsca](@ghRepo)
 * [EmergentOrder/ONNX-Scala](@ghRepo)


### PR DESCRIPTION
This repo is currently deleted, so we should remove it from template.md