### PR TITLE
Add iltotore/iron project

### DIFF
--- a/template.md
+++ b/template.md
@@ -462,6 +462,7 @@ Name | Description | GitHub Activity
 * [ISCPIF/freedsl](@ghRepo)
 * [frees-io/freestyle](@ghRepo)
 * [scala-hamsters/hamsters](@ghRepo)
+* [iltotore/iron](@ghRepo)
 * [maxcellent/lamma](@ghRepo)
 * [xerial/larray](@ghRepo)
 * [Log4s/log4s](@ghRepo)


### PR DESCRIPTION
Add [iltotore/iron](https://github.com/Iltotore/iron), a library for refinement types/type constraints. I placed it in the right category then following alphabetical order.