### PR TITLE
Add philwalk/uni to the list of repositories

### DIFF
--- a/template.md
+++ b/template.md
@@ -341,6 +341,7 @@ Name | Description | GitHub Activity
 * [eaplatanios/tensorflow_scala](@ghRepo)
 * [apache/zeppelin](@ghRepo)
 * [JohnSnowLabs/spark-nlp](@ghRepo)
+* [philwalk/uni](@ghRepo)
 * [HexagonNico/VecMatLib](@ghRepo)
 
 ### Big Data


### PR DESCRIPTION
[uni](https://index.scala-lang.org/philwalk/uni) provides a high-performance, NumPy-inspired linear algebra interface for Scala 3.

Key highlights for the list:

- Zero-Overhead: Leverages Scala 3 Opaque Types so Mat[T] has no wrapper overhead at runtime.
- Reproducibility: Features 1:1 faithful implementations of NumPy's PCG64-based random generation.
- Performance: Includes parallel fork/join primitives for activation functions that can outperform single-core SIMD implementations.
- I have added the entry to template.md using the @ghRepo tag as requested in the contribution guidelines.
